### PR TITLE
feat(tofu): manage repo settings and protect main

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -3,3 +3,10 @@
 # direnv exports these when you cd into the repo. Only the variable list is
 # tracked; values stay local. Exports land in follow-up commits as the tools
 # that need them arrive.
+
+# OpenTofu: GitHub App auth. IDs come from https://github.com/settings/apps;
+# the PEM is the App's private key downloaded at creation, stored under
+# ~/.config/homelab/ with chmod 600.
+export TF_VAR_github_app_id="REPLACE_ME"
+export TF_VAR_github_installation_id="REPLACE_ME"
+export TF_VAR_github_app_pem_path="$HOME/.config/homelab/REPLACE_ME.pem"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,7 @@ This repository describes my personal homelab, so I do not expect external contr
 ## Branching and merging
 
 - Branches: `feat/<name>`, `fix/<name>`, `docs/<name>`, and so on.
+- `main` requires signed commits, linear history, and a passing lint check.
 - Merges are local: rebase the feature branch onto `main`, then `git merge --ff-only` and push. The PR auto-closes; per-commit history stays visible on the PR page.
 
 ## Layout

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.11.1"
+  constraints = "~> 6.11"
+  hashes = [
+    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
+    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
+    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
+    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
+    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
+    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
+    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
+    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
+    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
+    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
+    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
+    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
+    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
+    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
+    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/opentofu/github.tf
+++ b/opentofu/github.tf
@@ -1,0 +1,45 @@
+resource "github_repository" "infra" {
+  name        = "infra"
+  description = "Declarative infrastructure for my single-node homelab."
+  visibility  = "public"
+  topics      = ["homelab", "infrastructure-as-code"]
+
+  has_issues      = true
+  has_discussions = false
+  has_projects    = false
+  has_wiki        = false
+
+  # Merge flow is local rebase + `git merge --ff-only` + direct push to main.
+  # The UI merge buttons are never used. GitHub refuses to disable all three
+  # together when required_linear_history is on, so squash stays enabled and
+  # the discipline is "don't click it". Rebase-merge would replay commits as
+  # unsigned and fail require_signed_commits; merge-commit would break linear
+  # history.
+  allow_merge_commit     = false
+  allow_rebase_merge     = false
+  allow_squash_merge     = true
+  allow_auto_merge       = false
+  delete_branch_on_merge = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# main's protection: signed commits, linear history, passing CI. PR reviews
+# not required; the merge flow is an ff-push from the laptop, not a UI click.
+resource "github_branch_protection" "main" {
+  repository_id = github_repository.infra.node_id
+  pattern       = "main"
+
+  enforce_admins          = true
+  require_signed_commits  = true
+  required_linear_history = true
+  allows_force_pushes     = false
+  allows_deletions        = false
+
+  required_status_checks {
+    strict   = true
+    contexts = ["pre-commit"]
+  }
+}

--- a/opentofu/providers.tf
+++ b/opentofu/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.11"
+    }
+  }
+}
+
+# GitHub App auth. The App's PEM signs a fresh 1-hour installation token per
+# run, so laptop-side PATs aren't in the loop.
+provider "github" {
+  owner = "shariq-farooqui"
+
+  app_auth {
+    id              = var.github_app_id
+    installation_id = var.github_installation_id
+    pem_file        = file(var.github_app_pem_path)
+  }
+}

--- a/opentofu/variables.tf
+++ b/opentofu/variables.tf
@@ -1,0 +1,14 @@
+variable "github_app_id" {
+  type        = string
+  description = "Numeric App ID of the GitHub App used for authentication."
+}
+
+variable "github_installation_id" {
+  type        = string
+  description = "Installation ID of the GitHub App on this account."
+}
+
+variable "github_app_pem_path" {
+  type        = string
+  description = "Absolute path to the App's private key PEM on the operator's machine."
+}


### PR DESCRIPTION
OpenTofu now manages the `infra` repo and `main`'s protection. `tofu plan` shows 1 to add (branch protection), 1 to change (repo toggles), 0 to destroy. Apply runs from the laptop post-merge.