### PR TITLE
feat(homelab): nixos host, k3s, restic and r2 bucket

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,8 +1,7 @@
 # Local-only environment. Copy to .envrc, fill in, then `direnv allow`.
 #
 # direnv exports these when you cd into the repo. Only the variable list is
-# tracked; values stay local. Exports land in follow-up commits as the tools
-# that need them arrive.
+# tracked; values stay local.
 
 # OpenTofu: GitHub App auth. IDs come from https://github.com/settings/apps;
 # the PEM is the App's private key downloaded at creation, stored under
@@ -10,3 +9,13 @@
 export TF_VAR_github_app_id="REPLACE_ME"
 export TF_VAR_github_installation_id="REPLACE_ME"
 export TF_VAR_github_app_pem_path="$HOME/.config/homelab/REPLACE_ME.pem"
+
+# sops: path to the operator's age private key. sops reads this when you
+# `sops <file>` to edit an encrypted secret. Public recipient is listed
+# in .sops.yaml; the private half never leaves ~/.config/homelab/.
+export SOPS_AGE_KEY_FILE="$HOME/.config/homelab/sops-operator.key"
+
+# Cloudflare: API token consumed by the cloudflare tofu provider. Scope
+# the token narrowly in dash.cloudflare.com: Account > Workers R2
+# Storage:Edit is enough for everything this repo manages today.
+export CLOUDFLARE_API_TOKEN="REPLACE_ME"

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,16 @@
+---
+# sops encryption policy: creation_rules define which files get encrypted and
+# which age public keys can decrypt them.
+#
+# Rules are evaluated top-to-bottom against path_regex; the first match wins.
+# When a new recipient joins, add its age public key under `age:` and run
+# `sops updatekeys <file>` on every existing encrypted file so the stored
+# ciphertext is re-encrypted to include the new recipient.
+creation_rules:
+  # Host secrets for the homelab: decrypt on the laptop (operator edits) and
+  # on the host itself (sops-nix decrypts at NixOS activation time using the
+  # host's SSH ed25519 key, converted to age via ssh-to-age).
+  - path_regex: nixos/hosts/.+/secrets\.yaml$
+    age: >-
+      age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl,
+      age1w6ty2zykemu7rq3effs4xl9mucrc0smesm5ad8nhzam63ljhv5sqy63l3t

--- a/nixos/flake.lock
+++ b/nixos/flake.lock
@@ -1,0 +1,70 @@
+{
+  "nodes": {
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768920986,
+        "narHash": "sha256-CNzzBsRhq7gg4BMBuTDObiWDH/rFYHEuDRVOwCcwXw4=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "de5708739256238fb912c62f03988815db89ec9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v1.13.0",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "disko": "disko",
+        "nixpkgs": "nixpkgs",
+        "sops-nix": "sops-nix"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776119890,
+        "narHash": "sha256-Zm6bxLNnEOYuS/SzrAGsYuXSwk3cbkRQZY0fJnk8a5M=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "d4971dd58c6627bfee52a1ad4237637c0a2fb0cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nixos/flake.nix
+++ b/nixos/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "Homelab host configuration";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    disko = {
+      url = "github:nix-community/disko/v1.13.0";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, disko, sops-nix, ... }: {
+    nixosConfigurations.homelab = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        disko.nixosModules.disko
+        sops-nix.nixosModules.sops
+        ./hosts/homelab
+      ];
+    };
+  };
+}

--- a/nixos/hosts/homelab/default.nix
+++ b/nixos/hosts/homelab/default.nix
@@ -1,0 +1,374 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ./hardware.nix
+    ./disko.nix
+  ];
+
+  networking.hostName = "homelab";
+  time.timeZone = "Europe/London";
+  i18n.defaultLocale = "en_GB.UTF-8";
+  # TTY keymap for local console access (Hetzner rescue, QEMU VM). SSH
+  # sessions use the client's keyboard layout, so this only matters
+  # when the console is used directly.
+  console.keyMap = "uk";
+
+  # systemd-boot on the ESP. configurationLimit caps the number of old
+  # generations kept in the boot menu, so /boot doesn't slowly fill.
+  boot.loader.systemd-boot.enable = true;
+  boot.loader.systemd-boot.configurationLimit = 10;
+  boot.loader.efi.canTouchEfiVariables = true;
+
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
+  nix.settings.auto-optimise-store = true;
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 30d";
+  };
+
+  # Declarative-only users: no `passwd` drift between the flake and reality.
+  users.mutableUsers = false;
+  users.users.shariq = {
+    isNormalUser = true;
+    description = "Shariq Farooqui";
+    extraGroups = [ "wheel" ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOInT3AgWAoQ8RX8KDy26bVCJoHrrAIyvUMjrgRtU7Fb shariq.farooqui+dev@proton.me"
+    ];
+  };
+  # "!" in /etc/shadow means "no valid password hash"; root cannot log in
+  # by password and (combined with PermitRootLogin=no) not by SSH either.
+  users.users.root.hashedPassword = "!";
+
+  security.sudo = {
+    enable = true;
+    wheelNeedsPassword = false;
+  };
+
+  services.openssh = {
+    enable = true;
+    # openFirewall defaults to true, which adds port 22 to the firewall's
+    # allowedTCPPorts and therefore makes SSH reachable on the public
+    # interface regardless of trustedInterfaces. Disable it; SSH arrives
+    # via the tailscale0 interface and is covered by the trustedInterfaces
+    # rule in networking.firewall below.
+    openFirewall = false;
+    settings = {
+      PasswordAuthentication = false;
+      PermitRootLogin = "no";
+      KbdInteractiveAuthentication = false;
+    };
+  };
+
+  # Tailscale enrols non-interactively on first boot via a pre-auth key
+  # decrypted from sops. That means openssh.openFirewall can stay false
+  # from the start: the host reaches the tailnet before anyone tries to
+  # SSH to it. From then on it's `ssh shariq@homelab` over Tailscale, no
+  # client-side keys needed.
+  services.tailscale = {
+    enable = true;
+    authKeyFile = config.sops.secrets.tailscale_auth_key.path;
+    extraUpFlags = [ "--ssh" ];
+  };
+
+  # nftables is the kernel-native firewall backend. NixOS speaks both,
+  # prefer the modern one.
+  networking.nftables.enable = true;
+  networking.firewall = {
+    enable = true;
+    # Trusted interfaces bypass the per-port rules of this firewall.
+    # - tailscale0: SSH, nixos-rebuild pushes, tailnet-only services.
+    # - cni0: k3s's CNI bridge. Pod-to-service traffic DNATs to the node
+    #   IP and then hits the INPUT chain with iifname=cni0, so the chain
+    #   must accept it or core cluster services (coredns, metrics-server,
+    #   local-path-provisioner) can't reach the kube-apiserver and fail
+    #   to start. This is a known k3s-on-NixOS gotcha.
+    # Tailscale's WireGuard UDP on the public interface is opened by
+    # services.tailscale (openFirewall defaults to true).
+    trustedInterfaces = [ "tailscale0" "cni0" ];
+    # Public 443 is the only port that reaches this host from the
+    # internet. Cloudflare proxies *.farooqui.ai A records here; the
+    # Traefik ingress inside the cluster terminates TLS with mTLS via
+    # Authenticated Origin Pulls so that a direct hit on the Hetzner IP
+    # can't impersonate Cloudflare.
+    allowedTCPPorts = [ 443 ];
+  };
+
+  # DHCP on all wired interfaces via systemd-networkd.
+  networking.useNetworkd = true;
+  systemd.network.enable = true;
+
+  # Operator shell baseline plus kubectl and fluxcd for cluster-side work
+  # from the host itself.
+  environment.systemPackages = with pkgs; [
+    git
+    vim
+    tmux
+    htop
+    dua
+    just
+    fzf
+    kubectl
+    fluxcd
+  ];
+
+  # k3s, single-node. --write-kubeconfig-mode=0644 lets shariq read
+  # /etc/rancher/k3s/k3s.yaml without sudo (needed to scp it off the
+  # box for a local kubectl). The API server binds :6443 on all
+  # interfaces; the firewall still drops public inbound because 6443
+  # isn't in allowedTCPPorts, and tailscale0 is trusted, so the tailnet
+  # can reach the API. Default CNI is flannel, default service CIDR is
+  # 10.43.0.0/16 (doesn't clash with tailscale's 100.64.0.0/10).
+  # --disable traefik turns off the k3s-bundled Traefik so a Flux-managed
+  # HelmRelease can be the only ingress controller on the cluster.
+  services.k3s = {
+    enable = true;
+    role = "server";
+    extraFlags = [
+      "--write-kubeconfig-mode=0644"
+      "--disable=traefik"
+    ];
+  };
+
+  # Operator shell ergonomics.
+  #
+  # zsh with syntax highlighting, ghost-text history suggestions, and a
+  # deduplicated shared history large enough to span a month of
+  # interactive work. fzf wires Ctrl-R for fuzzy history search, Ctrl-T
+  # for a fuzzy file picker, and Alt-C for directory jumping.
+  #
+  # starship renders a compact prompt that always shows host and user
+  # so SSH sessions on multiple boxes are obvious at a glance.
+  #
+  # EDITOR / VISUAL point tools like git at vim by default; LESS is
+  # tuned to preserve colours, match search case-insensitively, and
+  # exit on single-screen output.
+  users.users.shariq.shell = pkgs.zsh;
+
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    autosuggestions.enable = true;
+    syntaxHighlighting.enable = true;
+    histSize = 100000;
+    setOptions = [
+      # History is shared live across concurrent shells and saved as
+      # each command is issued, not at shell exit. Deduplicated both
+      # at write time and across the whole file so the buffer stays
+      # dense with real commands.
+      "SHARE_HISTORY"
+      "INC_APPEND_HISTORY"
+      "EXTENDED_HISTORY"
+      "HIST_IGNORE_DUPS"
+      "HIST_IGNORE_ALL_DUPS"
+      "HIST_SAVE_NO_DUPS"
+      # Commands starting with a leading space are skipped, handy
+      # when pasting anything sensitive that shouldn't land on disk.
+      "HIST_IGNORE_SPACE"
+      # Navigation conveniences: bare directory names cd into them,
+      # cd maintains a stack, duplicate entries on the stack collapse.
+      "AUTO_CD"
+      "AUTO_PUSHD"
+      "PUSHD_IGNORE_DUPS"
+      # `#` comments are allowed on the interactive line so blocks
+      # pasted from scripts or PRs don't blow up.
+      "INTERACTIVE_COMMENTS"
+    ];
+    interactiveShellInit = ''
+      source ${pkgs.fzf}/share/fzf/key-bindings.zsh
+      source ${pkgs.fzf}/share/fzf/completion.zsh
+    '';
+  };
+
+  programs.starship = {
+    enable = true;
+    settings = {
+      add_newline = false;
+      # Single-line prompt: user@host path git-state > on one row.
+      format = lib.concatStrings [
+        "$username" "$hostname" "$directory"
+        "$git_branch" "$git_status"
+        "$cmd_duration"
+        "$character"
+      ];
+      # Hex values are the standard gruvbox-dark bright variants; they
+      # render as gruvbox in any truecolor terminal regardless of the
+      # terminal's configured palette.
+      username = {
+        show_always = true;
+        format = "[$user]($style)@";
+        style_user = "#8ec07c bold"; # bright aqua
+        style_root = "#fb4934 bold"; # bright red — visual alarm for root
+      };
+      hostname = {
+        ssh_only = false;
+        format = "[$hostname]($style) ";
+        style = "#83a598 bold"; # bright blue
+      };
+      directory = {
+        truncation_length = 3;
+        truncation_symbol = ".../";
+        format = "[$path]($style) ";
+        style = "#fabd2f bold"; # bright yellow
+      };
+      git_branch = {
+        symbol = "";
+        format = "on [$branch]($style) ";
+        style = "#d3869b bold"; # bright purple
+      };
+      git_status = {
+        format = "[$all_status$ahead_behind]($style) ";
+        style = "#fb4934 bold"; # bright red
+      };
+      cmd_duration = {
+        min_time = 2000;
+        format = "took [$duration]($style) ";
+        style = "#fabd2f"; # bright yellow (not bold, softer weight)
+      };
+      character = {
+        success_symbol = "[>](#b8bb26 bold)"; # bright green
+        error_symbol = "[>](#fb4934 bold)";   # bright red
+      };
+    };
+  };
+
+  environment.variables = {
+    EDITOR = "vim";
+    VISUAL = "vim";
+    PAGER = "less";
+    LESS = "-R -i -M -F";
+    # kubectl without KUBECONFIG falls back to http://localhost:8080, the
+    # pre-kubeconfig default that no modern cluster uses. k3s writes its
+    # kubeconfig to /etc/rancher/k3s/k3s.yaml (readable because services.k3s
+    # sets --write-kubeconfig-mode=0644); point kubectl at it system-wide
+    # so `kubectl get nodes` works without flags.
+    KUBECONFIG = "/etc/rancher/k3s/k3s.yaml";
+  };
+
+  environment.shellAliases = {
+    ll = "ls -la --color=auto";
+    la = "ls -a --color=auto";
+    l = "ls -CF --color=auto";
+    ".." = "cd ..";
+    "..." = "cd ../..";
+    "...." = "cd ../../..";
+    sctl = "systemctl";
+    jctl = "journalctl";
+  };
+
+  # Suppress zsh's first-run "newuser install" wizard. The wizard triggers
+  # when a user has no ~/.zshrc, ~/.zshenv, ~/.zprofile, or ~/.zlogin
+  # and blocks the interactive prompt until dismissed. All real zsh
+  # config already lives system-wide in /etc/zshrc via programs.zsh;
+  # the wizard's job is redundant here. An empty ~/.zshrc satisfies the
+  # check without overriding anything. tmpfiles only creates the file
+  # if it doesn't exist, so operator edits survive.
+  systemd.tmpfiles.rules = [
+    "f /home/shariq/.zshrc 0644 shariq users -"
+  ];
+
+  # Secrets. sops-nix decrypts SOPS-encrypted YAML at activation time and
+  # writes plaintext to /run/secrets/<name>. The decryption key is the
+  # host's SSH ed25519 host key at /etc/ssh/ssh_host_ed25519_key, converted
+  # to age internally by sops-nix. The key itself is pre-generated on the
+  # laptop and injected via nixos-anywhere's --extra-files so the operator
+  # knows the host's age recipient before the box exists and can encrypt
+  # secrets.yaml to it. The operator's own age recipient is listed in
+  # .sops.yaml too, so sops edits from the laptop work.
+  sops.defaultSopsFile = ./secrets.yaml;
+  sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+  sops.secrets = {
+    tailscale_auth_key = { };
+    r2_repository_url = { };
+    r2_access_key_id = { };
+    r2_secret_access_key = { };
+    restic_repo_password = { };
+  };
+  # Template file that restic's systemd unit loads as an EnvironmentFile.
+  # sops placeholders resolve at runtime when restic starts.
+  sops.templates.restic_env = {
+    content = ''
+      AWS_ACCESS_KEY_ID=${config.sops.placeholder.r2_access_key_id}
+      AWS_SECRET_ACCESS_KEY=${config.sops.placeholder.r2_secret_access_key}
+    '';
+    mode = "0400";
+    owner = "root";
+    group = "root";
+  };
+
+  # Restic backup to Cloudflare R2. `services.restic.backups.<name>`
+  # generates a systemd timer + service. The repo URL, password and R2
+  # access credentials all come from sops; restic encrypts everything
+  # client-side, so R2 only sees opaque blobs.
+  services.restic.backups.homelab = {
+    initialize = true;
+    repositoryFile = config.sops.secrets.r2_repository_url.path;
+    passwordFile = config.sops.secrets.restic_repo_password.path;
+    environmentFile = config.sops.templates.restic_env.path;
+    paths = [
+      "/var/lib/rancher/k3s/server/db"
+      "/var/lib/rancher/k3s/storage"
+    ];
+    timerConfig = {
+      OnCalendar = "daily";
+      Persistent = true;
+      RandomizedDelaySec = "1h";
+    };
+    pruneOpts = [
+      "--keep-daily 7"
+      "--keep-weekly 4"
+      "--keep-monthly 6"
+    ];
+  };
+
+  # Cap journald retention so the btrfs pool can't fill from logs alone.
+  # 2 GiB is generous for a single host; MaxRetentionSec drops anything
+  # older than a month regardless; MaxFileSec rotates weekly so each
+  # journal file stays readable by `journalctl --file`.
+  services.journald.extraConfig = ''
+    SystemMaxUse=2G
+    MaxRetentionSec=1month
+    MaxFileSec=1week
+  '';
+
+  # Weekly auto-upgrade against the flake. The upgrade service pulls the
+  # latest nixpkgs-25.11 tip, rebuilds, and activates. Failed rebuilds
+  # leave the previous generation running; no operator action is needed
+  # unless a build error appears in the logs. persistent = true means a
+  # missed timer (host was off) runs on next boot.
+  system.autoUpgrade = {
+    enable = true;
+    flake = "github:shariq-farooqui/infra?dir=nixos";
+    flags = [
+      "--update-input" "nixpkgs"
+      "-L" # stream build logs to journald
+    ];
+    dates = "weekly";
+    randomizedDelaySec = "45min";
+    operation = "switch";
+    persistent = true;
+  };
+
+  # Pins the NixOS release this host targets. Never change after first
+  # install without a documented migration: some modules (Postgres, etc.)
+  # use this to decide upgrade paths.
+  system.stateVersion = "25.11";
+
+  # Applies ONLY when building the .vm derivation
+  # (nix run .#nixosConfigurations.homelab.config.system.build.vm). The
+  # real toplevel system is unaffected, so production shariq stays
+  # SSH-key-only with no password. Inside the VM, an empty password plus
+  # PAM's null-password allowance plus getty autologin boots straight to
+  # a shell, letting the operator verify services come up cleanly before
+  # any nixos-anywhere run.
+  virtualisation.vmVariant = {
+    virtualisation.memorySize = 2048;
+    virtualisation.cores = 2;
+
+    users.users.shariq.hashedPassword = lib.mkForce "";
+    security.pam.services.login.allowNullPassword = true;
+    services.getty.autologinUser = "shariq";
+  };
+}

--- a/nixos/hosts/homelab/disko.nix
+++ b/nixos/hosts/homelab/disko.nix
@@ -1,0 +1,97 @@
+{
+  # Two 1 TB Samsung NVMe SSDs in a single btrfs filesystem.
+  # - metadata: raid1 across both drives (~sub-GB overhead, free reliability)
+  # - data: single (no mirroring, 2 TB usable, drive loss = partial data loss)
+  # - compression: zstd level 3 inline
+  # - restic to R2 covers recoverable-value data; btrfs is for capacity.
+  #
+  # /dev/disk/by-id paths are stable across PCIe re-enumeration. Device IDs
+  # confirmed against the target from the Hetzner rescue system. The "a"
+  # and "b" attr names are arbitrary labels for the disko blocks; they do
+  # not correspond to the kernel's /dev/nvme0n1 vs /dev/nvme1n1 naming,
+  # which comes from PCIe enumeration and isn't a stable reference.
+  #
+  # The btrfs mkfs lives on b's disko block, not a's. Disko processes
+  # disks in attr-key declaration order, so partitioning a first ensures
+  # its pool partition already exists by the time b's btrfs mkfs runs
+  # with a's partition as the extra device. Putting the btrfs on a
+  # (with b as extra device) inverts that and fails with "No such file"
+  # because b hasn't been partitioned yet.
+  disko.devices = {
+    disk = {
+      a = {
+        type = "disk";
+        device = "/dev/disk/by-id/nvme-SAMSUNG_MZVLB1T0HBLR-00000_S4GJNX0R532212";
+        content = {
+          type = "gpt";
+          partitions = {
+            # UEFI System Partition. systemd-boot and kernel images live here.
+            ESP = {
+              priority = 1;
+              size = "512M";
+              type = "EF00";
+              content = {
+                type = "filesystem";
+                format = "vfat";
+                mountpoint = "/boot";
+                # Keep the ESP readable only by root; the bootloader doesn't
+                # need world access.
+                mountOptions = [ "umask=0077" ];
+              };
+            };
+            # Plain GPT partition covering the rest of a. No content
+            # type here, so disko leaves it as a raw slice. It gets
+            # consumed by the btrfs mkfs declared on b.
+            pool = {
+              size = "100%";
+            };
+          };
+        };
+      };
+      b = {
+        type = "disk";
+        device = "/dev/disk/by-id/nvme-SAMSUNG_MZVLB1T0HBLR-00000_S4GJNX0R535805";
+        content = {
+          type = "gpt";
+          partitions = {
+            # b's pool partition runs mkfs.btrfs with a's pool
+            # partition (referenced by its disko partlabel) as the extra
+            # device. Subvolumes are declared here and provide the final
+            # mount layout.
+            pool = {
+              size = "100%";
+              content = {
+                type = "btrfs";
+                extraArgs = [
+                  "-L" "homelab"
+                  "-d" "single"
+                  "-m" "raid1"
+                  "-f"
+                  "/dev/disk/by-partlabel/disk-a-pool"
+                ];
+                subvolumes = {
+                  "@root" = {
+                    mountpoint = "/";
+                    mountOptions = [ "compress=zstd:3" "noatime" ];
+                  };
+                  "@nix" = {
+                    mountpoint = "/nix";
+                    mountOptions = [ "compress=zstd:3" "noatime" ];
+                  };
+                  "@home" = {
+                    mountpoint = "/home";
+                    mountOptions = [ "compress=zstd:3" "noatime" ];
+                  };
+                  "@log" = {
+                    mountpoint = "/var/log";
+                    mountOptions = [ "compress=zstd:3" "noatime" ];
+                  };
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+}

--- a/nixos/hosts/homelab/hardware.nix
+++ b/nixos/hosts/homelab/hardware.nix
@@ -1,0 +1,26 @@
+{ lib, modulesPath, ... }:
+
+{
+  # Pulls in sensible defaults for hardware that nixos-generate-config would
+  # otherwise detect on an existing installation.
+  imports = [ (modulesPath + "/installer/scan/not-detected.nix") ];
+
+  # Intel i7-8700 (Coffee Lake).
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault true;
+  boot.kernelModules = [ "kvm-intel" ];
+
+  # Modules the kernel must load before the real root filesystem is mounted
+  # (from the initramfs): NVMe for the root device, ahci in case of a legacy
+  # controller on the same board, xhci_pci + usbhid to keep emergency USB
+  # input working at boot.
+  boot.initrd.availableKernelModules = [
+    "nvme"
+    "xhci_pci"
+    "ahci"
+    "usbhid"
+  ];
+
+  hardware.enableRedistributableFirmware = true;
+
+  nix.settings.max-jobs = lib.mkDefault "auto";
+}

--- a/nixos/hosts/homelab/secrets.yaml
+++ b/nixos/hosts/homelab/secrets.yaml
@@ -1,0 +1,29 @@
+tailscale_auth_key: ENC[AES256_GCM,data:0cui7QM/iXBJSt/ivOtOU7zXGb5+Uhdo7s29M4v50kdoo7SSrtsINwst98Q0Srx/My0PQg6iAQpUBJc26g==,iv:GPlt/QbXmJWpJ3/0ILGVuRCeWGfVrZMJdeggExdwp4E=,tag:FwBJojX6syTQgVPw4uzkeQ==,type:str]
+r2_repository_url: ENC[AES256_GCM,data:xWkResAAs8Eqai5k7PiUuqz3YexV2SRM96WI+PaJKB79PzNyiu1I6rnodqhtPdAmRorpET6I6sx6zY40wrbei5ZpK2cQhs63y/OHCA==,iv:WFbW3VuSSUznujXM8XqTiSIwxV2qQWbn9Dib4evsm1A=,tag:C7ZPGV7pCDPRse/g1oN2mQ==,type:str]
+r2_access_key_id: ENC[AES256_GCM,data:IEaYIA6/zUxIkt3dnyf/Fjc8GBgr3oXQ0jHKcsYXk3Y=,iv:lOI28JzJlLFUPFqlL/wkDW96eJJ7yBTA1ErFzxrFwh4=,tag:r7WK+q6/ReuYvFpsBqet3w==,type:str]
+r2_secret_access_key: ENC[AES256_GCM,data:tWKg+FbsXGbZVqpVtqSlopupWCgzuHbIeSDFLIwc56RVURW2b4XLlxdiIvK4RNxluDspUGSIsbU9g+4WWwrOLg==,iv:m/AsZjl2uDGMpwHtxXM6VbBjjG7dE8QJ/RCX4PAmhkI=,tag:7mpZoKTL20EUxpG/9eIY2Q==,type:str]
+restic_repo_password: ENC[AES256_GCM,data:B93LlUGm19ayR2CFrXEB74oS2nXwigdVXBr+XvnViX52iJCkkXLAJPilbqJ/qxuRhzynazBirs4bIwrdcX1X9A==,iv:877nuiFJ63x8Yr8acVg8vosQkyVOCsPBC57PDYPknWo=,tag:IJwTdoFks7aO23Jy71H2iA==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpbHEwOHVTa0ViWGFqZ1hq
+            bkM5d3pQWGVqWkJpWGo5N1hWNnJsc2VBWGh3CmlzZWU3eFNKWHhHSnJraGRNUzFk
+            NE92ZGx6MXRtM3lFSU1tQWhYY3hSVEUKLS0tIHA2V3VyY3lsQnhyNWkxeWQ4aDZj
+            U1FKd2pBbEp5ZGFLT1ZYTWpuWVNwSjgKc1tM8at/WYxEvPOlk0TsTSXQQxREFkvd
+            zm3LXaKIsfDyrWi5Z/xrZK1mLVTavcXHPVagwinnW5Higto68iGzow==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1w6ty2zykemu7rq3effs4xl9mucrc0smesm5ad8nhzam63ljhv5sqy63l3t
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaWHV2WFdYeUMxUjRtRUJG
+            VG5qM2FDTHNwd0ZvdkRTVEJYckNDTFdpczNzCnZjTUJyUVFoRnBsTnN0MjcxcklK
+            TkJtdzBUQzZyMXREZjRLTHR1M0RPMXMKLS0tIGZhNFlvQnVmaHNZU1hjUVA5TVBr
+            U3lFR2FEc2x3aW5jdnMvRzBFYXQwdEEKw2lrCWqh3M+THaD6ULhga5kwO7JBbNXm
+            3wH5CRpuvg80XrrB5vAS0Mwpg/vCzy7XTyCX4TBKvRZbHp+jUr/2Ig==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T10:29:56Z"
+    mac: ENC[AES256_GCM,data:I9lBm4o5fEl7H8IE05N5Qr+R09RbutqQXlRoLWB05Ij+v4N+TxsNWqSyYNW3xWcNKQLSXyWq0ATkXdiLLBJb3AXPL+uIUvb9clLEfYddyS0/jlWmFAHgwv5wrIN2qf4m77No1xwnd6D80ifpOo9huumbGVR9a+ajL0XSN1KQIu8=,iv:J3KQpsYLQ9ObEy18HSUDmZ+NaDBNXdcxe4KHTOxW+Xs=,tag:9wIi/gAshwaLio4aDetYgQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -1,6 +1,29 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "4.52.7"
+  constraints = "~> 4.52"
+  hashes = [
+    "h1:pPItIWii5oymR+geZB219ROSPuSODPLTlM4S/u8xLvM=",
+    "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
+    "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
+    "zh:556a568a6f0235e8f41647de9e4d3a1e7b1d6502df8b19b54ec441f1c653ea10",
+    "zh:633ebbd5b0245e75e500ef9be4d9e62288f97e8da3baaa51323892a786d90285",
+    "zh:6acfe60cf52a65ba8f044f748548d2119e7f4fd7f8ebcb14698960d87c68f529",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:904acc31ebb9d6ef68c792074b30532ee61bf515f19e0a3c75b46f126cca1f13",
+    "zh:a1d0a81246afc8750286d3f6fe7a8fbe6460dd2662407b28dbfbabb612e5fa9d",
+    "zh:a41a36fe253fc365fe2b7ffc749624688b2693b4634862fda161179ab100029f",
+    "zh:a7ef269e77ffa8715c8945a2c14322c7ff159ea44c15f62505f3cbb2cae3b32d",
+    "zh:b01aa3bed30610633b762df64332b26f8844a68c3960cebcb30f04918efc67fe",
+    "zh:b069cc2cd18cae10757df3ae030508eac8d55de7e49eda7a5e3e11f2f7fe6455",
+    "zh:b2d2c6313729ebb7465dceece374049e2d08bda34473901be9ff46a8836d42b2",
+    "zh:db0e114edaf4bc2f3d4769958807c83022bfbc619a00bdf4c4bd17faa4ab2d8b",
+    "zh:ecc0aa8b9044f664fd2aaf8fa992d976578f78478980555b4b8f6148e8d1a5fe",
+  ]
+}
+
 provider "registry.opentofu.org/integrations/github" {
   version     = "6.11.1"
   constraints = "~> 6.11"

--- a/opentofu/cloudflare.tf
+++ b/opentofu/cloudflare.tf
@@ -1,0 +1,19 @@
+data "cloudflare_accounts" "main" {}
+
+# R2 bucket for restic backups. Located in WEUR (western Europe) so the
+# Falkenstein host has a short round-trip; R2 egress to the internet is
+# free so region choice is about latency, not cost.
+resource "cloudflare_r2_bucket" "backups" {
+  account_id = data.cloudflare_accounts.main.accounts[0].id
+  name       = "homelab"
+  location   = "WEUR"
+}
+
+# Full S3-compatible URL for restic's r2_repository_url sops secret. Marked
+# sensitive because the account ID in the hostname ties the repo to a
+# specific Cloudflare account and shouldn't appear in CI logs.
+output "restic_r2_repository_url" {
+  description = "Paste into the r2_repository_url sops secret in nixos/hosts/homelab/secrets.yaml."
+  value       = "s3:https://${data.cloudflare_accounts.main.accounts[0].id}.r2.cloudflarestorage.com/${cloudflare_r2_bucket.backups.name}"
+  sensitive   = true
+}

--- a/opentofu/providers.tf
+++ b/opentofu/providers.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "integrations/github"
       version = "~> 6.11"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.52"
+    }
   }
 }
 
@@ -20,3 +24,7 @@ provider "github" {
     pem_file        = file(var.github_app_pem_path)
   }
 }
+
+# Cloudflare provider reads CLOUDFLARE_API_TOKEN from the environment. Token
+# scopes needed so far: Account > Workers R2 Storage:Edit (for the R2 bucket).
+provider "cloudflare" {}


### PR DESCRIPTION
Deployment from the laptop after merge:

1. Boot the Hetzner box into the rescue system.
2. `tofu -chdir=opentofu apply` (only if the R2 bucket isn't already created; this PR creates it).
3. `nixos-anywhere --flake .#homelab --extra-files ~/.config/homelab/hostkeys root@<hetzner-ip>`.

Activation proves the sops → tailscale → k3s → restic chain end-to-end.