### PR TITLE
fix(cluster): traefik http-to-https redirect syntax for chart v34+

### DIFF
--- a/infrastructure/controllers/traefik/release.yaml
+++ b/infrastructure/controllers/traefik/release.yaml
@@ -49,8 +49,11 @@ spec:
         # Permanent redirect to HTTPS. Public :80 is firewalled so this
         # only fires for tailnet clients; Cloudflare handles the public
         # case at its edge via the Always-Use-HTTPS zone setting.
-        redirectTo:
-          port: websecure
+        redirections:
+          entryPoint:
+            to: websecure
+            scheme: https
+            permanent: true
       websecure:
         port: 443
         expose:


### PR DESCRIPTION
Traefik chart 36.x removed the `redirectTo:` values key in v34 and replaced it with the nested `redirections.entryPoint:` form. The original value caused Helm install to abort. This PR uses the current syntax so the HelmRelease succeeds.