### PR TITLE
fix(site): tmp emptydir so nginx-unprivileged can boot read-only

### DIFF
--- a/apps/personal-site/deployment.yaml
+++ b/apps/personal-site/deployment.yaml
@@ -40,10 +40,21 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
+          # nginx-unprivileged runs as uid 101 and writes its PID and temp
+          # paths under /tmp; an emptyDir there lets readOnlyRootFilesystem
+          # stay true while nginx still starts.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsNonRoot: true
             capabilities:
               drop:
                 - ALL
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi


### PR DESCRIPTION
Verified against the Dockerfile in the personal-site repo: base image is `nginxinc/nginx-unprivileged:1.30.0-alpine3.23`, which puts nginx's PID and temp paths under `/tmp`. A 64Mi emptyDir at `/tmp` lets the pod keep `readOnlyRootFilesystem: true` while nginx boots.