### PR TITLE
feat(cluster): observability with tailscale-operator for grafana

### DIFF
--- a/infrastructure/configs/observability/grafana-ingress.yaml
+++ b/infrastructure/configs/observability/grafana-ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: observability
+spec:
+  # ingressClassName: tailscale tells the Tailscale Operator to expose
+  # this Service on the tailnet rather than through Traefik. TLS and
+  # hostname registration happen inside the operator; no cert-manager
+  # or DNS plumbing needed.
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - monitoring
+      secretName: monitoring-tls
+  rules:
+    - host: monitoring
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: kps-grafana
+                port:
+                  number: 80

--- a/infrastructure/configs/observability/kustomization.yaml
+++ b/infrastructure/configs/observability/kustomization.yaml
@@ -1,7 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - tailscale-operator
-  - observability
+  - secrets.yaml
+  - grafana-ingress.yaml

--- a/infrastructure/configs/observability/secrets.yaml
+++ b/infrastructure/configs/observability/secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: ENC[AES256_GCM,data:Fn0=,iv:SVzPT8fx3HMYPOrOr1lt7u0Om16xGMTM77HXdoolwtU=,tag:0ammtU28wGOQzykzSB5F3w==,type:str]
+kind: ENC[AES256_GCM,data:izQ/Qf53,iv:6DB3EHUsh2KMu5MkhGR9iV1DMBM/fDHphcx7lL9tk+c=,tag:qa0iQNo9PboJCCXG/rfrGA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:uUbMYL+kfKPmNl/b8g==,iv:T3KWFNTjeIYULlaSkxHyOVNng8AXjx8NMj14ZRHE2u8=,tag:8XytdYIQpL8mttfmHBmkcg==,type:str]
+    namespace: ENC[AES256_GCM,data:YKA/uTXOkTV3xZhjug==,iv:T55za68Qrx8PESS7koPElORxkNmKftuO7zQ6adfBabg=,tag:yYAlsd9pWxEyrZqHzj4z9w==,type:str]
+type: ENC[AES256_GCM,data:eP+GoSDl,iv:eT38YIyTQ8U26ICeS2R1KU1yBLrtANVf574FWDRKSHI=,tag:jUU9yKpA6LeocXZQh3dNEA==,type:str]
+stringData:
+    values.yaml: ENC[AES256_GCM,data:74QO+NCJKynHKzC8MXx3COdANHl0Ijwq5OWNK33yk7bRGLIgvVXmKI1dBo72muQLhbIM5ih7lxaR8YtP/6NxzImd9I3uBIm8hEj/Kx7R1Vxgtiuab23swE4kVm+IdUWc6fdcmjNCH5wHYGVW9u0/6U3M5iluT+ZMXE0PE90lgkUZ40leRtQZfQolfRnMFg==,iv:iFZ91xMVapEDwkb23Fq4k/a8J905KgVfqTV6Ypi/cJE=,tag:uwsJ1BKwVmsNeH/jE3RmUQ==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFczRCQ0Nob2NGUGlxZENR
+            K0N3RG43ckp0b3o4bERWNit5Z2xTcTFUZkhBClc0VXNkdXNTaXRocVpsYkk2LzVw
+            c09jMGVXQWlXajIvTG00eTFaajh0R1EKLS0tIEhrL3VkTXd1U3J1MlFsMjhKazVI
+            ZmZlb2UyVHBuVksxblVzZEZyVjFyRXcKAC8BWczJTocwo57UqfheJrg5ODo6Xdk/
+            /H6Pkpc4/iTBs8rMqG7h/j1JLv7gNdjeYHQsoSkxFxcT/HhpnixgBA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1YXpwWTdGVldnQkpXTXJO
+            eU1WUGM5d2hTUGJpcE1ONUJiZytYdDNWbTBJCmFkQnZUV2FtVndESWJsRGdnK2xX
+            QUt0UVY1S296d0xJZDlteDVzbGZkUkUKLS0tIGEyb3VzM0pua0JSdjBLSS9DbkV5
+            THI0U1VjdS9DbEgrZVE1bTZlUjlMN3cKaxy+fI9mM9fc5WUXLpx6x4mMqxhmWl3G
+            Z+FKEcujSdrqw4+6IAZIfCUImd8bmV5CWAoncW8bMjlKtrkC47GOpA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T15:12:57Z"
+    mac: ENC[AES256_GCM,data:fe9A31fWSviSxCqFIT1qtkIFNMCr11r8nw9DnsdjWmMNNJWr72rquzHqhScXr5I7dY5EpKZRhtXzjbedn1gRH8JYVx5ZMPRxBXtZzdjSYQ3aKhS63Ofukl3CHc3r5NZxQNcJMxHEXpnVYrH53ar/MF2/HfQpgw/0ATA+I7BddiM=,iv:sADXspgFgRePpmATqamxqvko0kDeUHlcOyyjdTaErt0=,tag:3wMp+F2NhPafN82WAmEjCQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/infrastructure/configs/tailscale-operator/kustomization.yaml
+++ b/infrastructure/configs/tailscale-operator/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - tailscale-operator
+  - secrets.yaml

--- a/infrastructure/configs/tailscale-operator/secrets.yaml
+++ b/infrastructure/configs/tailscale-operator/secrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: ENC[AES256_GCM,data:Aos=,iv:4IGAulxAtltBSw9XcwVwT7BcVQulMjaJR8ZEac7eCbE=,tag:s1uD4qfVpsVLqI+l4MZ7vg==,type:str]
+kind: ENC[AES256_GCM,data:PvTV9RrA,iv:lLsbYIOl+cEqKvhjbJo7GeFk1mUh9HWeHZE46TDpG68=,tag:apfUnHoDecRB3/NFZD3fgQ==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:2K6G6Kf3WFT65vccZ9cqQgpNSyPLlJS/,iv:sXfbIhHOkWB2JBrkSdxUooc5w8xvsq5FooQhhOceuhs=,tag:kmiqbruFSR6mUkB4vrnrJw==,type:str]
+    namespace: ENC[AES256_GCM,data:SXEG7WasPFe7,iv:gqv05pcGXhb6wvpBXz9111Dg/IwkB6kKOXBwhENh+/k=,tag:ifVNFOuD2bvfg/UVYZi4Eg==,type:str]
+type: ENC[AES256_GCM,data:xCP6dluB,iv:v+rwe8WxwW/38SPQoTzzMxFQrjx8WZZ6t6pHIk5b+qU=,tag:KJ/WKzHYtnpIZ4Ou6UwM4A==,type:str]
+stringData:
+    values.yaml: ENC[AES256_GCM,data:4YXCEYlrNzuWNGSzjogetOzMA/g6aSqa5tYVoV4D7hf/dYbgbUqdnmn9i6XAxf09nGCcsKyoUIwKViyrvCZyT5gJ5BSn7ljQDzCjIYhmBnUol4hmML6vGeosbdWiTB2wxD16WYSTxJMukyZdgbnJqCw3B6ah,iv:2hHxRIVQJk3wV+1b1+HSdhQ0PSqQKeAHHXO4re29qbI=,tag:yhImJn6m6cv8B7q1RtD7iQ==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkUkZ3UEFZSEZPYlNXWkZ5
+            Nkc5UTlPd0NqWVF0cjhDak5vcW1LZDhObDFZCm5UZHdEZDROVzY5VGliZVI2MlFk
+            UEdOdytwMXJmakI3NjZUN2dTZDlFSFkKLS0tIHhtd2VrYWJvTm8wdFhTUThyV2Fn
+            N3J2aDRBNjZvZGR6MzdWZS95Sy9KekkKJFQivyYqPll7f9kDziOfPPiDPBGR9nIh
+            u/gukoVKejy3C3OkYD4/5GYBXacrqd8+Ar/Nwjq+RVgXzRHR05/CsA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Z21CclNkZnFqdVpDYWVI
+            S3pIT2pZSnhkVk4wZVI3UG1PYWE1UUtlS1FjCldmT1oyOVNZejZXaDRYVXJSRWlT
+            bldtMUtXWW1pN2djTjB6NXAxRisyZ3MKLS0tIDQ1T1BGajNqUzhJV1VydHZCRmVT
+            REMwVWpQV0lQTmxNYjFMZDEzWE1RZ28KwA8gJzxlPbQYYq+iruOQdzwOHE8s4YRh
+            xnN1JCwtJawzhrMeh10TAADn8RMD3SplG+B5XeaYBWLveHNNoaA8eA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T15:06:03Z"
+    mac: ENC[AES256_GCM,data:hv01usjztNR5PrlxOkgo0Y072q7zcHmFAQfdEPEb1rwZBGEQ9f06JnUnCin2ZBO3fxleAPwkQwrTf39flgE9uZpxlG5PD7KZhB14EJ6tf/i50bMvn/10T7e7VBcWOzdPWAbPSsRZkB8KzZPGnlxunqaVV8ja7DqG2J/l0mfTwvs=,iv:bLFOFSaXdT+j7BFX+/3vv89q6G1yxMB6248CBQUfVd0=,tag:XwnCM8fF7xutZ0eSc5rLfQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - cert-manager
   - traefik
   - tailscale-operator
+  - observability

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - cert-manager
   - traefik
+  - tailscale-operator

--- a/infrastructure/controllers/observability/alloy.yaml
+++ b/infrastructure/controllers/observability/alloy.yaml
@@ -1,0 +1,81 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy
+  namespace: observability
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: alloy
+      version: "1.7.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: observability
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # DaemonSet so one Alloy agent runs per node and tails that node's
+    # container stdout/stderr. Single-node cluster means one agent.
+    controller:
+      type: daemonset
+    alloy:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+      # River config: discover kubernetes pods, relabel to carry
+      # namespace/pod/container into Loki labels, forward to the Loki
+      # gateway in-cluster.
+      configMap:
+        create: true
+        content: |
+          discovery.kubernetes "pods" {
+            role = "pod"
+          }
+
+          discovery.relabel "pod_logs" {
+            targets = discovery.kubernetes.pods.targets
+
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_node_name"]
+              target_label  = "node"
+            }
+            rule {
+              action = "replace"
+              source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+              separator = "/"
+              target_label = "job"
+            }
+          }
+
+          loki.source.kubernetes "pods" {
+            targets    = discovery.relabel.pod_logs.output
+            forward_to = [loki.write.default.receiver]
+          }
+
+          loki.write "default" {
+            endpoint {
+              url = "http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
+            }
+          }

--- a/infrastructure/controllers/observability/kube-prometheus-stack.yaml
+++ b/infrastructure/controllers/observability/kube-prometheus-stack.yaml
@@ -1,0 +1,92 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: observability
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      version: "83.7.0"
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: observability
+      interval: 1h
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: grafana-admin
+      valuesKey: values.yaml
+  values:
+    # Single-node cluster, so one replica of everything, modest retention,
+    # and local-path PVCs for anything that wants state. Alertmanager is
+    # off until there's a live alert rule worth routing.
+    fullnameOverride: kps
+    alertmanager:
+      enabled: false
+    prometheus:
+      prometheusSpec:
+        retention: 7d
+        replicas: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+        storageSpec:
+          volumeClaimTemplate:
+            spec:
+              storageClassName: local-path
+              accessModes: ["ReadWriteOnce"]
+              resources:
+                requests:
+                  storage: 10Gi
+        # Pick up ServiceMonitors across all namespaces so adding one to a
+        # future workload's kustomization is all that's needed.
+        serviceMonitorSelectorNilUsesHelmValues: false
+        podMonitorSelectorNilUsesHelmValues: false
+        probeSelectorNilUsesHelmValues: false
+        ruleSelectorNilUsesHelmValues: false
+    grafana:
+      replicas: 1
+      defaultDashboardsTimezone: Europe/London
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+      persistence:
+        enabled: true
+        storageClassName: local-path
+        size: 2Gi
+      # Grafana's own LE Ingress is off; the tailnet-scoped Ingress lives
+      # under configs/observability with ingressClassName: tailscale.
+      ingress:
+        enabled: false
+      # Loki data source wired in at install so logs + metrics share a pane
+      # on day one. Prometheus data source is created by the stack itself.
+      additionalDataSources:
+        - name: Loki
+          type: loki
+          url: http://loki-gateway.observability.svc.cluster.local
+          access: proxy
+          isDefault: false
+    kubeProxy:
+      # k3s-built-in kube-proxy doesn't expose a metrics endpoint on the
+      # default path; disable the ServiceMonitor so Prometheus doesn't
+      # alert on a scrape that can never succeed.
+      enabled: false
+    # Traefik runs in its own namespace and is scraped via a ServiceMonitor
+    # emitted by its Helm chart (enabled in traefik release values), so the
+    # stack doesn't need to scrape it here.

--- a/infrastructure/controllers/observability/kustomization.yaml
+++ b/infrastructure/controllers/observability/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repositories.yaml
+  - kube-prometheus-stack.yaml
+  - loki.yaml
+  - alloy.yaml

--- a/infrastructure/controllers/observability/loki.yaml
+++ b/infrastructure/controllers/observability/loki.yaml
@@ -1,0 +1,86 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: observability
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: loki
+      version: "6.55.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: observability
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Monolithic (SingleBinary) mode: one pod runs reader, writer and
+    # backend. Distributed mode is for multi-node scale-out; on a single
+    # homelab host the single binary is the maintained minimum.
+    deploymentMode: SingleBinary
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      # Schema v13 is the current stable; previous repos defaulted to v11
+      # which is no longer the chart default and triggers a noisy warning.
+      schemaConfig:
+        configs:
+          - from: "2024-04-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      storage:
+        type: filesystem
+      # Ingester limits reduced to cut memory on a 128 GB box with plenty
+      # of headroom but no need to tune for scale.
+      limits_config:
+        retention_period: 30d
+        allow_structured_metadata: true
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: local-path
+        size: 10Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+    # SimpleScalable and Distributed modes share the same values tree as
+    # SingleBinary; zero them explicitly so the chart's validate hook
+    # doesn't trip on "both modes have replicas > 0".
+    write:
+      replicas: 0
+    read:
+      replicas: 0
+    backend:
+      replicas: 0
+    # Subcharts not needed in single-binary mode; disable to keep the
+    # install surface tight.
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    lokiCanary:
+      enabled: false
+    test:
+      enabled: false
+    # Default config pulls in a "gateway" nginx pod. Keep it — Grafana's
+    # data source points at http://loki-gateway.observability.svc, which
+    # is easier than threading the write/read path through data sources.
+    gateway:
+      enabled: true
+      replicas: 1

--- a/infrastructure/controllers/observability/namespace.yaml
+++ b/infrastructure/controllers/observability/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: observability

--- a/infrastructure/controllers/observability/repositories.yaml
+++ b/infrastructure/controllers/observability/repositories.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-community
+  namespace: observability
+spec:
+  interval: 1h
+  url: https://prometheus-community.github.io/helm-charts
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: observability
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts

--- a/infrastructure/controllers/tailscale-operator/kustomization.yaml
+++ b/infrastructure/controllers/tailscale-operator/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - cert-manager
-  - traefik
-  - tailscale-operator
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/tailscale-operator/namespace.yaml
+++ b/infrastructure/controllers/tailscale-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale

--- a/infrastructure/controllers/tailscale-operator/release.yaml
+++ b/infrastructure/controllers/tailscale-operator/release.yaml
@@ -1,0 +1,34 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+  namespace: tailscale
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: "1.96.5"
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale
+        namespace: tailscale
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  # OAuth client credentials come from the sops-encrypted Secret deployed
+  # alongside (configs/tailscale-operator/secrets.yaml). The chart's values
+  # are merged with that Secret's data.values key at install time.
+  valuesFrom:
+    - kind: Secret
+      name: tailscale-operator-oauth
+      valuesKey: values.yaml
+  values:
+    operatorConfig:
+      hostname: tailscale-operator
+    apiServerProxyConfig:
+      mode: "false"

--- a/infrastructure/controllers/tailscale-operator/repository.yaml
+++ b/infrastructure/controllers/tailscale-operator/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale
+  namespace: tailscale
+spec:
+  interval: 1h
+  url: https://pkgs.tailscale.com/helmcharts


### PR DESCRIPTION
Two commits:
1. Tailscale Operator — Ingresses with `ingressClassName: tailscale` get a tailnet-only endpoint + TS-issued cert, no cert-manager / DNS plumbing.
2. Observability stack — kube-prometheus-stack (Prometheus + Grafana, Alertmanager off), Loki in SingleBinary, Alloy DaemonSet scraping container logs into Loki. Grafana exposed at `monitoring.tail92ef59.ts.net`.

Deployment, laptop-side after merge:

1. Tailscale admin console → Settings → OAuth clients → Create new. Scope: `Devices Core: Read & Write`, `Tags: Write`. Allow tag: `tag:k8s-operator`. Note the client ID and secret.
2. Tailscale admin console → Access controls → add to the policy JSON:
   ```json
   "tagOwners": {
     "tag:k8s-operator": ["autogroup:admin"],
     "tag:k8s": ["tag:k8s-operator"]
   }
   ```
3. `sops infrastructure/configs/tailscale-operator/secrets.yaml` → fill `oauth.clientId` and `oauth.clientSecret`.
4. `sops infrastructure/configs/observability/secrets.yaml` → paste `~/.config/homelab/grafana-admin-password` into `grafana.adminPassword`.
5. Flux reconciles. Grafana comes up, operator enrols the tailnet sidecar, `monitoring.tail92ef59.ts.net` resolves.