### PR TITLE
fix(obs): point grafana ingress at the subchart's actual service name

### DIFF
--- a/infrastructure/configs/observability/grafana-ingress.yaml
+++ b/infrastructure/configs/observability/grafana-ingress.yaml
@@ -21,6 +21,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: kps-grafana
+                name: grafana
                 port:
                   number: 80

--- a/infrastructure/controllers/observability/kube-prometheus-stack.yaml
+++ b/infrastructure/controllers/observability/kube-prometheus-stack.yaml
@@ -59,6 +59,9 @@ spec:
         ruleSelectorNilUsesHelmValues: false
     grafana:
       replicas: 1
+      # Grafana is a subchart so the umbrella fullnameOverride doesn't
+      # reach it; set it explicitly so the Service lands at `grafana`.
+      fullnameOverride: grafana
       defaultDashboardsTimezone: Europe/London
       resources:
         requests:


### PR DESCRIPTION
The parent chart's `fullnameOverride: kps` doesn't propagate to the Grafana subchart, so its Service lands at `kube-prometheus-stack-grafana`. Setting `grafana.fullnameOverride: grafana` shortens it, and the Ingress is updated to match.