### PR TITLE
feat(umami): shared postgres + reflector + umami analytics

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -18,7 +18,12 @@ creation_rules:
   # time. Two recipients: the laptop (so `sops <file>` can decrypt in-place
   # for edits) and the cluster's dedicated age keypair, whose private half
   # lives as a Secret named `sops-age` in the flux-system namespace.
+  #
+  # encrypted_regex keeps apiVersion/kind/metadata plaintext so kustomize
+  # and flux-local can parse the Secret structurally; only the `data` and
+  # `stringData` fields get encrypted.
   - path_regex: (infrastructure|apps)/.*/secrets\.ya?ml$
+    encrypted_regex: "^(data|stringData)$"
     age: >-
       age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl,
       age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9

--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - personal-site
   - gatus
+  - umami

--- a/apps/umami/db-init-job.yaml
+++ b/apps/umami/db-init-job.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: umami-db-init
+  namespace: umami
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: init
+          image: postgres:18.3-alpine
+          env:
+            # Admin password is reflected into this namespace by the
+            # reflector operator; the source lives in the postgres
+            # namespace and is never copied into app sops blobs.
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-admin
+                  key: password
+            - name: UMAMI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: umami
+                  key: db-password
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              psql -h postgres.postgres.svc.cluster.local -U postgres \
+                -v ON_ERROR_STOP=1 <<SQL
+              SELECT 'CREATE ROLE umami WITH LOGIN PASSWORD ''${UMAMI_PASSWORD}'''
+              WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'umami')
+              \gexec
+              ALTER ROLE umami WITH LOGIN PASSWORD '${UMAMI_PASSWORD}';
+
+              SELECT 'CREATE DATABASE umami OWNER umami'
+              WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'umami')
+              \gexec
+
+              REVOKE ALL ON DATABASE umami FROM PUBLIC;
+              GRANT CONNECT ON DATABASE umami TO umami;
+              SQL
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 70
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/apps/umami/deployment.yaml
+++ b/apps/umami/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: umami
+  namespace: umami
+  labels:
+    app.kubernetes.io/name: umami
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: umami
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: umami
+    spec:
+      containers:
+        - name: umami
+          image: ghcr.io/umami-software/umami:postgresql-v3.1.0
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: DATABASE_TYPE
+              value: postgresql
+            # $(VAR) is k8s env-var interpolation: POSTGRES_PASSWORD is
+            # pulled from the secret, then baked into DATABASE_URL at
+            # pod start. Keeps the password out of the static manifest.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: umami
+                  key: db-password
+            - name: DATABASE_URL
+              value: postgresql://umami:$(POSTGRES_PASSWORD)@postgres.postgres.svc.cluster.local:5432/umami
+            - name: APP_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: umami
+                  key: app-secret
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /api/heartbeat
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/heartbeat
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL

--- a/apps/umami/ingress.yaml
+++ b/apps/umami/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: umami
+  namespace: umami
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.tls.options: traefik-cloudflare-origin-pull@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - analytics.farooqui.ai
+      secretName: analytics-farooqui-tls
+  rules:
+    - host: analytics.farooqui.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: umami
+                port:
+                  number: 80

--- a/apps/umami/kustomization.yaml
+++ b/apps/umami/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - secrets.yaml
+  - db-init-job.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/umami/namespace.yaml
+++ b/apps/umami/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: umami
+  labels:
+    # Opt-in to the postgres NetworkPolicy so umami's pods can reach the
+    # shared postgres server. Only labelled namespaces are allowed.
+    postgres-client: "true"

--- a/apps/umami/secrets.yaml
+++ b/apps/umami/secrets.yaml
@@ -1,0 +1,35 @@
+apiVersion: ENC[AES256_GCM,data:ENE=,iv:9yHfeuRjRPc8QfTl/IXN0DXcLvBmWRdiCp2kHrSre9c=,tag:ogqfQQbW9NNB/bI+vgTObg==,type:str]
+kind: ENC[AES256_GCM,data:d1Wo3dfB,iv:NKa8mYHWAkyGKiyXlYMLLQC1A/gsHvGgBH8gRjwaTFY=,tag:z60UhStU2BuT+BBwWFUyNA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:5gOKnvg=,iv:s9QK0RxHvmsm9bLi/90KZtKD2T0Nvbr160yAlxGixWE=,tag:i5qzOM6eXqgWsZqShwWaaw==,type:str]
+    namespace: ENC[AES256_GCM,data:MPdVEC4=,iv:sGXpc9G7DdWhTH+4yRE4JVvXLAiazenog+XURlzUAzQ=,tag:jhEzu/7Nb3hXRi5rOkF+pg==,type:str]
+type: ENC[AES256_GCM,data:MXfmWFSR,iv:SnN2F2t64PyDZO0eRhFd4M53fh0anK33EHQlNV5YzAM=,tag:j1TQBEAwNAt9qYJPhzxQUA==,type:str]
+stringData:
+    #ENC[AES256_GCM,data:qoOXwDlwdW3DascwkoUCXTP1ewyuYFYZAOXMuJWzaFZfj3PcqrOY6uhHS9DnLboYn9je9jQd+UcLukbRgPY0H+RJ7JkxzBeZq2kQ+g==,iv:w+71tfwkmYaXjSkIeluM8Ihm9bmtYDbd3t0xf7ii05w=,tag:FiVyFg/Tzg+TFvhW92yMng==,type:comment]
+    db-password: ENC[AES256_GCM,data:3U73eNW/E/wkOZ3eHLAAs+oJccqusZoG,iv:FEbnEveETgK3bflPkQ3v/OEQnAG9+vgaTx3QPlA5Mnk=,tag:rIAevRUB0LJWM/mHZLgYIQ==,type:str]
+    #ENC[AES256_GCM,data:LJlzSv2+b7YDBwOng67Hy2QXGH9ymllmTD5l1B+ACGsSGZP936d1uH9C872tQRwbBkUKGQB7inzm403n2Znbd8TjdRCvl8otVYLpgy4=,iv:XbYIMZbZNBlfptH+1IKc1qM7NTdBPniHBAInJynMtyc=,tag:T+gspNmHwWYUEg0G1rzvfg==,type:comment]
+    app-secret: ENC[AES256_GCM,data:CyI2eVgvXTzL/8z3xjRD8WKryF8xYHC0,iv:CspY4IhcK/QDoyjvOAIO7siWrE0Dqwqra/83PssBhSs=,tag:wcQ9oN4alS7vxo+u+7i/gw==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwdEttaHhHRXhlRlljUnda
+            bG51M2RpbENTb0lPVmUyWXNzQ0FycjdEdGcwCkhqRDdacnN6bnFBenZBYW9KSnN5
+            U09ydlg2ZDRVblJ3czBiOVBBWjk3SDgKLS0tIGhiL3c2bmhFREZBWG0zK2hwVU5I
+            eldhQThkblVZM0hUSTJzcW5iTTVkSjgKWVInqYpjA+qPLwNuxOi4Kv4RzJXDIIuQ
+            1Z1RdpKXh07DGL5Pq9atrjdIiM8d/xkp2s0O4Bwxa++Dc0yeb/bijg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QjdXdm44MzFEUW5KS0xM
+            Ky9BQUM3SUZHQnZaTmpGS1IwSktPRVVRUG1JCitnWkY2bHpLQ2hrcWo1WWhsakR4
+            aEpGV3BTOEwyVll5dlBoamR6WTc2b3MKLS0tIDhlVlQvZml5aXdhanNkV3NNQ2J0
+            a1NGZmExL3JDemJER1RWTm03Vk02Z00KNuTLBuzn4gN11DbpC+Di+2pgPF1Oh38I
+            JisnvHI/qM1xMGcxOjiJdNIHbDh0y/aZwz5vEEPTyYwgMK9ucVFB0g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T18:50:44Z"
+    mac: ENC[AES256_GCM,data:AnOzWaswhUulQxOTjzTQudCb8bmdsmQu0afnsbyOZocU9KjUdlm8KeitombNCcgcnE1+M5IGUZafSeI5xoq0vuXOHXGuE2lMCTYNgHZY1MquYS1XreIRbv4MV2BzHC6fJ982rt6Bpm7Fkpmqew7ckGKAaDChXDPrswITZt4oSzk=,iv:lR16nf9oGHrClWcwZ4qJOgjwzTSiFjaz5NSgONXqOlM=,tag:FNF7ho35lYHcg3L0lfNmrA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/apps/umami/secrets.yaml
+++ b/apps/umami/secrets.yaml
@@ -1,35 +1,35 @@
-apiVersion: ENC[AES256_GCM,data:ENE=,iv:9yHfeuRjRPc8QfTl/IXN0DXcLvBmWRdiCp2kHrSre9c=,tag:ogqfQQbW9NNB/bI+vgTObg==,type:str]
-kind: ENC[AES256_GCM,data:d1Wo3dfB,iv:NKa8mYHWAkyGKiyXlYMLLQC1A/gsHvGgBH8gRjwaTFY=,tag:z60UhStU2BuT+BBwWFUyNA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:5gOKnvg=,iv:s9QK0RxHvmsm9bLi/90KZtKD2T0Nvbr160yAlxGixWE=,tag:i5qzOM6eXqgWsZqShwWaaw==,type:str]
-    namespace: ENC[AES256_GCM,data:MPdVEC4=,iv:sGXpc9G7DdWhTH+4yRE4JVvXLAiazenog+XURlzUAzQ=,tag:jhEzu/7Nb3hXRi5rOkF+pg==,type:str]
-type: ENC[AES256_GCM,data:MXfmWFSR,iv:SnN2F2t64PyDZO0eRhFd4M53fh0anK33EHQlNV5YzAM=,tag:j1TQBEAwNAt9qYJPhzxQUA==,type:str]
+    name: umami
+    namespace: umami
+type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:qoOXwDlwdW3DascwkoUCXTP1ewyuYFYZAOXMuJWzaFZfj3PcqrOY6uhHS9DnLboYn9je9jQd+UcLukbRgPY0H+RJ7JkxzBeZq2kQ+g==,iv:w+71tfwkmYaXjSkIeluM8Ihm9bmtYDbd3t0xf7ii05w=,tag:FiVyFg/Tzg+TFvhW92yMng==,type:comment]
-    db-password: ENC[AES256_GCM,data:3U73eNW/E/wkOZ3eHLAAs+oJccqusZoG,iv:FEbnEveETgK3bflPkQ3v/OEQnAG9+vgaTx3QPlA5Mnk=,tag:rIAevRUB0LJWM/mHZLgYIQ==,type:str]
-    #ENC[AES256_GCM,data:LJlzSv2+b7YDBwOng67Hy2QXGH9ymllmTD5l1B+ACGsSGZP936d1uH9C872tQRwbBkUKGQB7inzm403n2Znbd8TjdRCvl8otVYLpgy4=,iv:XbYIMZbZNBlfptH+1IKc1qM7NTdBPniHBAInJynMtyc=,tag:T+gspNmHwWYUEg0G1rzvfg==,type:comment]
-    app-secret: ENC[AES256_GCM,data:CyI2eVgvXTzL/8z3xjRD8WKryF8xYHC0,iv:CspY4IhcK/QDoyjvOAIO7siWrE0Dqwqra/83PssBhSs=,tag:wcQ9oN4alS7vxo+u+7i/gw==,type:str]
+    #ENC[AES256_GCM,data:iUoVosBy4QBZ7BrZk8Dojp364e0bJX+MMCekfIgdqLcgzTExFbU7d6ZGExIdCQ7/Ju5x2lzpG3zwRGfWgyt2Qsl64B3FuHQXYfHq7g==,iv:s34ylAlabT1e37iPr05h4v0NQLXsn2ILrVRBVl+1nMc=,tag:SluMENWPZEPYDIhuhZ1X6g==,type:comment]
+    db-password: ENC[AES256_GCM,data:RLI80DCzkEWMOzFZTNmjxZQZVE3ZLOqWEXddVUK876D9NoEfgV7un/clO6//OWmud3cBGpU+4ko7almiLLpsWw==,iv:mlFK2moPlmeKxHEj4jX6RShNeXwBgWHdkHDGNu4hZOs=,tag:6xsx51Du3R/+kePdgBZUxA==,type:str]
+    #ENC[AES256_GCM,data:B/iTjsydQtHLdyWsLDd/Zx5h8e1zarCP1CeF7Xgl2EeW/nmKrVFAVdEQ3B+kBem9cdPX67sjFefORXkp6QkW8PzbQcOD44Y5WimjfKw=,iv:b1G78QuvEXTczVS9RPlbp5oZfmO0M0Fmyw3uH8ZqAMk=,tag:RCTjjtz6JERTVZJxMWBR+w==,type:comment]
+    app-secret: ENC[AES256_GCM,data:5YURPnMONvIZNJioXQ8fg52UPq9Ofodhu65N7cLS6JkNCgSXKMs/FBTuusLPf2PyJFC8w88l4t6LnJwoFN7Xgw==,iv:fTHU/gMP6C1RjRGbxZeEQiiq7T5QLDNauwBW4au6lwc=,tag:xhs/0FyXddcw37pNvZH0dw==,type:str]
 sops:
     age:
         - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwdEttaHhHRXhlRlljUnda
-            bG51M2RpbENTb0lPVmUyWXNzQ0FycjdEdGcwCkhqRDdacnN6bnFBenZBYW9KSnN5
-            U09ydlg2ZDRVblJ3czBiOVBBWjk3SDgKLS0tIGhiL3c2bmhFREZBWG0zK2hwVU5I
-            eldhQThkblVZM0hUSTJzcW5iTTVkSjgKWVInqYpjA+qPLwNuxOi4Kv4RzJXDIIuQ
-            1Z1RdpKXh07DGL5Pq9atrjdIiM8d/xkp2s0O4Bwxa++Dc0yeb/bijg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMdzFQMklhc05VcG15OGtu
+            Z0FJWUx1eXlEejI3QXZ0TFlCd2pjOU0vMDNJCmYzMW43V1ExWEJKZkV0d3ZBb1U2
+            QkRGbjN0TFp6N3Y1UzZraVFtLy92Q1UKLS0tIFA3VG81K2ExbjJJc0YvS2JmWWRT
+            RndZekdrMmpjM2RNT04xVm9PaVZqQlkKi3g+UolPIRtxFmhqs5KUI/1mKscA5u7I
+            LfuyTGW7FvdlCIco2Ka52iYRcy3X5LIU8/vsE5GveflBPn6zITqEyg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QjdXdm44MzFEUW5KS0xM
-            Ky9BQUM3SUZHQnZaTmpGS1IwSktPRVVRUG1JCitnWkY2bHpLQ2hrcWo1WWhsakR4
-            aEpGV3BTOEwyVll5dlBoamR6WTc2b3MKLS0tIDhlVlQvZml5aXdhanNkV3NNQ2J0
-            a1NGZmExL3JDemJER1RWTm03Vk02Z00KNuTLBuzn4gN11DbpC+Di+2pgPF1Oh38I
-            JisnvHI/qM1xMGcxOjiJdNIHbDh0y/aZwz5vEEPTyYwgMK9ucVFB0g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBESTZPQytrSythSXBXaUl3
+            MlNpMm9BWktZSVgybnpacHI5a0RmczlkbWdNCmQxclVJYTcvaHdIR3VmNGY3OUNj
+            aGFUR0UzaVBoeFpwYjNNZmdoZCtMVFUKLS0tIFVZTk5ZNFZJTGhmL0RvS3FPTmhu
+            QlB3a1lnRWIwaWNWWEVFbk5EcXdUQVEKB3bH806422+jZ8cOdakdjzCjnEzc/NDx
+            J02TBfEaZ5GuJzNL46R9+jvYMbXXhrd5Btj7Tgjpr/3S+Fkg8Z3dtA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T18:50:44Z"
-    mac: ENC[AES256_GCM,data:AnOzWaswhUulQxOTjzTQudCb8bmdsmQu0afnsbyOZocU9KjUdlm8KeitombNCcgcnE1+M5IGUZafSeI5xoq0vuXOHXGuE2lMCTYNgHZY1MquYS1XreIRbv4MV2BzHC6fJ982rt6Bpm7Fkpmqew7ckGKAaDChXDPrswITZt4oSzk=,iv:lR16nf9oGHrClWcwZ4qJOgjwzTSiFjaz5NSgONXqOlM=,tag:FNF7ho35lYHcg3L0lfNmrA==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-04-21T19:31:12Z"
+    mac: ENC[AES256_GCM,data:59D0Ol0lLm0Fg9G8xGGgKEKoxNOSOuJfrVH6SNBROdEHO/GIEtV5gRHm5cVFL/rIbbEyAPmk4mB3x1xbU6Rb9i/5mr4vnJaZBdw7HCvN/41qbNPahaCvwt7lWyjf1YXskWCKphct9451eGsgndKNh4YUt8tK15qyFFqntl+ZNug=,iv:S8P75RBIxTxcmUZXykuRK27ea3ebEDTIIRKfLRK44q0=,tag:NEE6tBXz3/8jDFBIcmEHdA==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/apps/umami/service.yaml
+++ b/apps/umami/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: umami
+  namespace: umami
+spec:
+  selector:
+    app.kubernetes.io/name: umami
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/infrastructure/configs/cert-manager/secrets.yaml
+++ b/infrastructure/configs/cert-manager/secrets.yaml
@@ -1,35 +1,35 @@
-apiVersion: ENC[AES256_GCM,data:3pA=,iv:5VUFmgMYcJUlV34RnorhPcYTsse1h9PJYJKMRL8rSHg=,tag:9jsw7QQrHzpZ09VCTpIovw==,type:str]
-kind: ENC[AES256_GCM,data:3EvHx6Yp,iv:SzV1TSdM5D6LBe4HLq0pi0ie35ZvzbF1+pkbSQcfh70=,tag:hniq5mLZ7Qt5u1o2fP10Tg==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:EMq1TRbHHtl6DmNq+iX/kfSkKuU=,iv:154tG5AiEhOCVmAhKycoOsTlYeVvfALHVVXaKTMPXzc=,tag:5Km7b2uogGkN04iAvok06A==,type:str]
-    namespace: ENC[AES256_GCM,data:Hc9+oecoLoArzgue,iv:A02/dASclCtXshTMjfdmMrxVTJ53ynvhnjfEuxjybd0=,tag:qYmVxtWxnKN4ba/2BP7enA==,type:str]
-type: ENC[AES256_GCM,data:9Wicey1B,iv:0VZdlr67W3IMzZYPcKczqbdTuJvnVx3fpf9LsUun950=,tag:XtfZjJ1ossUG5HPGbmxn4w==,type:str]
+    name: cloudflare-api-token
+    namespace: cert-manager
+type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:Z+oPus1JYJZE2FGozsvS0k7CMOmxIGj+va8N0t1fI7w9m1aC3kMZG7rluZnAtdVfEYwyMlllmZZsiWgLuxD0toA=,iv:CwfQoxZyyBGSEKnTZvo5rrKIzarJdHXPzKCf2hKZad8=,tag:NqwNALc+iorCnJjhm4GO+g==,type:comment]
-    #ENC[AES256_GCM,data:419Cq4pTO6WtIOQOvtwG8dTO8pJFy0QXO4HvIvXEOopc/dR9634qfyXLQT2QHbBJngEd7FK65w32+H7i4xw=,iv:ZkKZSHlOh94eQMWrkMEnGk0g8ya3XSRPtYrfO9L6JoU=,tag:/VWm2MimGfv/DTJ1uhv4Jg==,type:comment]
-    #ENC[AES256_GCM,data:0VTnnuCs3HdVNwIUQuBeea/fbWm/rYTsUbyn3folzrQcMoxsTLxr+mcboJWK9fYqlI6nnMo=,iv:4+CR8wuProTDu/T3Fix3piH7SR3mWisFSLrMgXpUrlE=,tag:3eGd7Ro2QsIwiXAhlWS8nw==,type:comment]
-    api-token: ENC[AES256_GCM,data:zCBtN9p75k7qp5Usra2NDXXErTMTSNmVCWdT/fD4QyeOoSPmkOLYKSP3rmyXjcZlEoAUGpg=,iv:/fnd91U3aqm25+4LwFfA5HI/cjVdRkNPqRm6fi98pX8=,tag:I3pUb+8+EAgciEw1YxfJow==,type:str]
+    #ENC[AES256_GCM,data:zxKyU2Cwr+plBalhTAjxpNXetFH/viZEOtw7Juen19MQ2wTbNOXl7ezK9hcQzUvmSKmehxCy42wKUb9Qjuu0rx0=,iv:zZsxPx+1B9UNQi+FSl/ZWB1NuXuBSnfcmnD+d8+pTjU=,tag:8DdYoEy7U5zm25+r9x0YaA==,type:comment]
+    #ENC[AES256_GCM,data:Rsx0SEgM9OhD/67jVJUke7Fl5O+3tdjQ1XvZ2mzykahR8f7JBvuctxOTfvzn1ZyLjP6WAFP8nje4ovvxVuM=,iv:hLqqAIK0ifg5aUG/J1ItA/71Y70PPhMuttSEPjnQgh0=,tag:8Wj/lT2bptplZwmxwssbWA==,type:comment]
+    #ENC[AES256_GCM,data:xssaMFcAYOzvU/1chCwu8F0ArmeJB+awGfuhTr5hXPSJTyadJCtgC017u/vpwDmTkbCMG2w=,iv:hrrP+xXHMEDIUxN94MSVbMUYVB2PspwOzB/NXlZMKXs=,tag:CTPSkClt6i/Hw/QVTUrObw==,type:comment]
+    api-token: ENC[AES256_GCM,data:4EHj8E5le4yx9j/jT35j0uUWSO+nN35Lt2pqGKo2evo+5yezlwx3eGkcKVi+WtNmIq/tQjI=,iv:yI2mPbgJ2+NdtuKFCKA6Sc9rOacP4MelOVvpqUCS8kE=,tag:fdLsRZVswhhWIp43X7uncw==,type:str]
 sops:
     age:
         - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3Mk1vUmRkU0hWb1g1c2x0
-            QVl1SlZzY00wQ21vUlJhSjBsK0FkQzkrYVRjCmNaQU5vTUJyNjhBMEpBU3hib25v
-            N0RaVkNpM2ttNVFmOVdPeGNITUpMenMKLS0tIE1pdTQ3a2ZNeWpkQStDdEtNSjV1
-            OUE5WWdGQkowM3U5bmMrQVEzTEI5NlkK1/d4K6frlOFjwHqzioeA6B8T4cJBMGFP
-            8bly5XcP8rK0kYCV+NRoFjLAfGfQNinRcEvuE8rlotwy3ospd5JHbw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxUEE0bC9URmw4bTdBVXlk
+            MUZXWXlha2tUM3QyclUra3B0bnRzRFc3bmdrCkZmbWI0WmRCOHhrYXlkWDlFcXRX
+            TEdDL1doZmxacSs0NS9ubkE1dHhlYXcKLS0tIGl5Wmx4UGFzWmRhNmhTK2VnWUZP
+            aG50a1FYWHBhQ2hEL1dXbEd1VDlMeHcK0EmP033RKByqJUgU8/lC/IDHJDSuYjqM
+            sVWJ/PTGUXdTovqLK25ppsNsdFyHHaJZrikSYE1oPQKRw4OCzqN7Ww==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLdHZuVjVlMC9sLy9OR0J2
-            cjJUakdUbzI5c1ovUFlaT0FIdmJMM1FCZDIwClZpRnpTL29Za0FieGdsOHUwbUh1
-            TENBMk5ObHc1c1pBZk1COU5FeGIwOUkKLS0tIEVTS2lDek9MZG5HRTRVaHBWRFdT
-            M3dtaW9aVzRpbTIrcFJlYkFWYnVhZXMKPQJe7IEarJrTw3EORIckwvg3LfBn3H9O
-            gLx+iDhxkGrv05JltYCmy44b7fayvqbDdeXGwJQZck5fNS6ZMMF7bA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWWmFDTCsxTDRzTmt0bTJq
+            c2RHRmRoWVVjM3RER3Z2NnRXUkFYd1ZkZTB3ClE4WVRaQ2hEN2RxVXg5aDI0c0hu
+            TDFCOTFHZjdVLzJ4VGpHdHl2eWVOTncKLS0tIHorZXVwbG5zRDIrbDIzYm9xbVAv
+            N2hZUjF3VFFJK1FmUHZHRklBb3lsWnMKL8lYYE/gWRKhsVgyzIqb7cacUwlQtUZu
+            IUDHuSqbj9MWSX5QNz973VHcirh1hX61sk5UcNGiO+5Ud7j4nAuuMw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T12:03:46Z"
-    mac: ENC[AES256_GCM,data:Ec+L20e5I9EBDgrKFD/wWRFDqbgoVKWRYKc9Y9JPD91TW0tHG2RK4T9Wyvw6JY6HegR98fynbxR8IOppYuKm0kRUuh/kzMxHsm6CfUDJ1XbIf4vUSbGwC3mSK3VSp0kACuvHfP2m/SfGWrgtX5iM0DSa5FUGfUp/gvO745aqn2Y=,iv:gb4Nxd3i8dP+RgGKUR0rQ/e+exw57Fhz1YwsIOR/1aU=,tag:nHdJu+vCEjowy2FsCncVXw==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-04-21T18:59:41Z"
+    mac: ENC[AES256_GCM,data:QsFpI+EC/s2a23y8UaL7/Cc6Bz/B2WmhQMyvTdv4PRn948wvn1ZSS79k+oHwtMI2OMYISnRjT/iYadv4uM3QE74qXwQCrsbFSBDWuwwte6mGO/3Qtg2iSFnIf+aZ0heMsLXEru1LunLQodpiekRVE3gvqe+TbtONz+x4qpY6ptg=,iv:aEwaib4SOdlLmJbmrLpK+SODe0vwWDVrHV900AX5Z1s=,tag:R9sDjTvQfa9qODmwOY3FYw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - traefik
   - tailscale-operator
   - observability
+  - reflector
+  - postgres

--- a/infrastructure/controllers/observability/secrets.yaml
+++ b/infrastructure/controllers/observability/secrets.yaml
@@ -1,32 +1,32 @@
-apiVersion: ENC[AES256_GCM,data:Fn0=,iv:SVzPT8fx3HMYPOrOr1lt7u0Om16xGMTM77HXdoolwtU=,tag:0ammtU28wGOQzykzSB5F3w==,type:str]
-kind: ENC[AES256_GCM,data:izQ/Qf53,iv:6DB3EHUsh2KMu5MkhGR9iV1DMBM/fDHphcx7lL9tk+c=,tag:qa0iQNo9PboJCCXG/rfrGA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:uUbMYL+kfKPmNl/b8g==,iv:T3KWFNTjeIYULlaSkxHyOVNng8AXjx8NMj14ZRHE2u8=,tag:8XytdYIQpL8mttfmHBmkcg==,type:str]
-    namespace: ENC[AES256_GCM,data:YKA/uTXOkTV3xZhjug==,iv:T55za68Qrx8PESS7koPElORxkNmKftuO7zQ6adfBabg=,tag:yYAlsd9pWxEyrZqHzj4z9w==,type:str]
-type: ENC[AES256_GCM,data:eP+GoSDl,iv:eT38YIyTQ8U26ICeS2R1KU1yBLrtANVf574FWDRKSHI=,tag:jUU9yKpA6LeocXZQh3dNEA==,type:str]
+    name: grafana-admin
+    namespace: observability
+type: Opaque
 stringData:
-    values.yaml: ENC[AES256_GCM,data:74QO+NCJKynHKzC8MXx3COdANHl0Ijwq5OWNK33yk7bRGLIgvVXmKI1dBo72muQLhbIM5ih7lxaR8YtP/6NxzImd9I3uBIm8hEj/Kx7R1Vxgtiuab23swE4kVm+IdUWc6fdcmjNCH5wHYGVW9u0/6U3M5iluT+ZMXE0PE90lgkUZ40leRtQZfQolfRnMFg==,iv:iFZ91xMVapEDwkb23Fq4k/a8J905KgVfqTV6Ypi/cJE=,tag:uwsJ1BKwVmsNeH/jE3RmUQ==,type:str]
+    values.yaml: ENC[AES256_GCM,data:qZgnFF+7Xbt8UiuzGz2o+w0MTosrqVTwS+eriggjJdtLtzH8OyondhfXcFqb9bheuaP1Zj86OrNoP3m6X4eG3eo6tVYfXNJHF/+IkvkE9jQA+3GiXXiBKq5X1v1CgYXATncqwHBJPBBFr9XP92CqH8gKGqovG1suIuygqDkMkRjeI01+D9ZxfY/TCiViCQ==,iv:/SYVb81QyCzM471qMdi0jHQ+RQ6ye+zibwDMjeAJUac=,tag:/84PbZZYb2C7cJP2D+etbQ==,type:str]
 sops:
     age:
         - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFczRCQ0Nob2NGUGlxZENR
-            K0N3RG43ckp0b3o4bERWNit5Z2xTcTFUZkhBClc0VXNkdXNTaXRocVpsYkk2LzVw
-            c09jMGVXQWlXajIvTG00eTFaajh0R1EKLS0tIEhrL3VkTXd1U3J1MlFsMjhKazVI
-            ZmZlb2UyVHBuVksxblVzZEZyVjFyRXcKAC8BWczJTocwo57UqfheJrg5ODo6Xdk/
-            /H6Pkpc4/iTBs8rMqG7h/j1JLv7gNdjeYHQsoSkxFxcT/HhpnixgBA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2T0U4WDhQbk9uU3pMLzZr
+            UFVDODZQTzBreXUwaHBKSEJSMWNjRFRRRG5rCmRjZTBZbDFGM21uTWpjSC9vOWhM
+            MDNVRWZXemdaaU41SmNPS2ZJU05NZlUKLS0tIGJDdHZHZVYzU3YzNjNGNk9LalE3
+            Nm5xMHY5SnNLVVo0N3pNMXVURTZkalEKhgwwXbua+Uj8I7xX3G9YIX2oPejFZBs+
+            HoXRWC2fP7X6/eAhWnBzNx1yyE3P+KlyqaGF8w1vWMKWqjYFbAJtcg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1YXpwWTdGVldnQkpXTXJO
-            eU1WUGM5d2hTUGJpcE1ONUJiZytYdDNWbTBJCmFkQnZUV2FtVndESWJsRGdnK2xX
-            QUt0UVY1S296d0xJZDlteDVzbGZkUkUKLS0tIGEyb3VzM0pua0JSdjBLSS9DbkV5
-            THI0U1VjdS9DbEgrZVE1bTZlUjlMN3cKaxy+fI9mM9fc5WUXLpx6x4mMqxhmWl3G
-            Z+FKEcujSdrqw4+6IAZIfCUImd8bmV5CWAoncW8bMjlKtrkC47GOpA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0Ujh6QnhDeHFWZ0tUSkJZ
+            L0xLL21hQ2NXbjRsMGJPZ1V5ZE9xRE5nOFhFCmM3ei9EemEzQmJxd2VmWWlST3hH
+            cFdabVZUb2lCRnZXVEdEcE82Vnl2RGcKLS0tIEp6VkIra3RJOWxQMkErQWhrR3Rl
+            OE1QMkxIU2dOWWIrOHdlRTRWT3JxL2cKzc06RJbrgccn7VGpRmwjjo/sO8356Gn9
+            RrEk1VTEhZi1bkK/m+mwpTRKhlhJjSdgwbng0Wo2LNzOwuncesr2LA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T15:12:57Z"
-    mac: ENC[AES256_GCM,data:fe9A31fWSviSxCqFIT1qtkIFNMCr11r8nw9DnsdjWmMNNJWr72rquzHqhScXr5I7dY5EpKZRhtXzjbedn1gRH8JYVx5ZMPRxBXtZzdjSYQ3aKhS63Ofukl3CHc3r5NZxQNcJMxHEXpnVYrH53ar/MF2/HfQpgw/0ATA+I7BddiM=,iv:sADXspgFgRePpmATqamxqvko0kDeUHlcOyyjdTaErt0=,tag:3wMp+F2NhPafN82WAmEjCQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-04-21T18:59:41Z"
+    mac: ENC[AES256_GCM,data:t2ZoEPj21jR3q3RrT8fKcMz62QQ5T/Z5iPoQZ+HXbxThkHh2BaSExf0W8pTivub927+9TVUhZZboRYYY+FtwFAv0NN6LFJbCmkYnputnWvnacY3njI0wUiX07UMOT17Op5QQuIXg7zPIx3xp6rOxG/g1lYqDX8HHgJSm84xjI7k=,iv:NzN+xpGz7Zm+1+A0WNLK2toXQBDc7cNEXkJ8UIiLx2I=,tag:aTuttHyq/moSwvBC8nBiTw==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/infrastructure/controllers/postgres/deployment.yaml
+++ b/infrastructure/controllers/postgres/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: postgres
+  labels:
+    app.kubernetes.io/name: postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:18.3-alpine
+          ports:
+            - name: pg
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-admin
+                  key: password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "postgres"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 70
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: postgres-data

--- a/infrastructure/controllers/postgres/kustomization.yaml
+++ b/infrastructure/controllers/postgres/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - secrets.yaml
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml

--- a/infrastructure/controllers/postgres/namespace.yaml
+++ b/infrastructure/controllers/postgres/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: postgres

--- a/infrastructure/controllers/postgres/networkpolicy.yaml
+++ b/infrastructure/controllers/postgres/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgres-ingress
+  namespace: postgres
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgres
+  policyTypes:
+    - Ingress
+  # Only namespaces that explicitly label themselves as postgres clients
+  # can reach the server. Each app opts in via its namespace metadata.
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              postgres-client: "true"
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/infrastructure/controllers/postgres/pvc.yaml
+++ b/infrastructure/controllers/postgres/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: postgres
+spec:
+  storageClassName: local-path
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi

--- a/infrastructure/controllers/postgres/secrets.yaml
+++ b/infrastructure/controllers/postgres/secrets.yaml
@@ -1,0 +1,41 @@
+apiVersion: ENC[AES256_GCM,data:eAE=,iv:Nq49qDnsgWQb92x2q0QLACxy2/MqmTGxhiMdz9Zs8lQ=,tag:ui2Uk3QRhMmZncEzvA/bkA==,type:str]
+kind: ENC[AES256_GCM,data:WoMQkzMz,iv:4syrQZh8Vmsl3WnUtuWyvsv+1bl8zX8/vZ21mvsvaTI=,tag:maoZDYpokwlfzqGj53i/bA==,type:str]
+metadata:
+    name: ENC[AES256_GCM,data:ZhP5QhNgPYQawbiYDr0=,iv:49Cjzp9LveZNfYIe0vgoE/ANQpU9YBD49RQr5Ztz9sY=,tag:1k0kdwEPnb4/VYzoM9TyAw==,type:str]
+    namespace: ENC[AES256_GCM,data:MY9sEBebcv0=,iv:Dz557ULU2tBeSuEZxq6bbyThBj3qE7xBdW10AULpQss=,tag:rPiTA4li5wQlt+fLn/+DGA==,type:str]
+    annotations:
+        #ENC[AES256_GCM,data:0e0YeUjOOxaeyQNJDyM7z3AcbNgIGxFp7NoJgETuD0qLxnynKOOJYF8BlCYgth4eZEzrDia27Uhd+Zsr6UyPdiOa,iv:sLItmjHSYTFXZjyM6FrKTik0VzDpvacb6zcP5i/ctiI=,tag:aWzNuxEWBECqzRDMBKTuGA==,type:comment]
+        #ENC[AES256_GCM,data:hA2S6FGISiAReDjM8OqhtbNmQpSJ/cP/VbG2Edo1GoV7xjaLzbk6PYpGP0SIuEVz4PoTcYEgh1ubRv6sgA==,iv:markitWneKkq3iLLZQZcWiYHavZ1/PBRIkBQ30gTNG8=,tag:LYqoBOUjhOUmKNivvsTwIw==,type:comment]
+        #ENC[AES256_GCM,data:s+IyOb52it+ehivBbPeoByssiCr9a/FX/vsobnNrEtGGIKmvBgZIGKM3Q4dS4Kl+SeFqlVffExrk9Y5JqaHJ,iv:ggfQJUydaAP83US8bj50nWqnbK8rlRYs2bb1TBfa4lk=,tag:es3Y3Orrp6i1UI2Ev6HYtw==,type:comment]
+        #ENC[AES256_GCM,data:Hjvt4BzV6jlsCIduL3kIwwvIq1ttmEWQCe1Y3X7dZIJ6wJCjGSkGrlk=,iv:jagfDUJjn3p4dJyZMscEc7HjGkXr1x4znIkdFPdoY98=,tag:gU/Ec6L8a9uzfqwYD2vI1w==,type:comment]
+        reflector.v1.k8s.emberstack.com/reflection-allowed: ENC[AES256_GCM,data:sTspmg==,iv:vgj+2PETMyYXr7qiwr256sQrc+YxyJCB3xNAP+N0FLI=,tag:UR6YpXzPYnnrlQl034zT4g==,type:str]
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ENC[AES256_GCM,data:j2URjF8=,iv:4QYBVfh42nHdWLe4UG7kvVO3755vD+pNBATlauveo9c=,tag:fNRG2GWonLH61sKas+XqNA==,type:str]
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: ENC[AES256_GCM,data:b3W3xw==,iv:QHHBAKBLh94OBZQjyj+/NDYh6V9Wt6F0qNbK6ysfJ8g=,tag:lP85fqYSkPnEvGn9+BaT1A==,type:str]
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: ENC[AES256_GCM,data:VYNE0vw=,iv:DLB1lN1DxlPd6rzeETWK7a7A3c8T4ybXCpyrTVkHCmM=,tag:cqZCvEOJrVO+bvmMcn7BEA==,type:str]
+type: ENC[AES256_GCM,data:lPXidmMG,iv:t7i8w8nG2v1xHYh+arKRnD8JW3vPIwKX3HaflHnbvo8=,tag:f7/ByJVEkVYJIZDVdGckAQ==,type:str]
+stringData:
+    password: ENC[AES256_GCM,data:2nuHDJIBnW20QK1D/FBJfaUHLtnKsHC1,iv:3quQhhMk3p7g5jRKdXECe6Yv4tkZPgzHJa+vEWvvHl8=,tag:ARNXs8oq6a+GsGFeW/JQfA==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZa21VNU45elJaTzBCSUIx
+            TFk1aUIvcGhjTnJnL3JDWDQ1Y0VBN3JGcmtVCjFwbEtXeDN5TFk3WnJxRjVNdG55
+            dEtXZ0tKQmdONUZxQmFELzNmMW0waHcKLS0tIG9RRUpJUHIzNVlwUldSS1RRL2JP
+            bWdFOHh6UGNZQVZ0b2hFNXowOGlab1kKdQJ7vB5PH+BSJrn6pZronj6FzsN7QEMi
+            dotQDv7yGQOr3N8gMUWg9aR6uko3fqgO7kevxbLgaEOZjV+rRFw4xA==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGS1JQV1N6YVl0ZW9tUXRi
+            NURVSVd3K3I3cmJSM1NGam1hTDkwKzBYM0NrClpGanNaa2xpK21xOWhDSGFLOG9u
+            MlJrSFFDYjR5M2MvbzFKbzZYSzJ1UUEKLS0tIFNha1BCZExBUEZURlFvRFBtWHJz
+            bnI0bG52ajlGN0FTL0gvQVpDaTVyT1UKXp6s4xl9ivq7HpFb9Cc1pvoDJUanZRO2
+            Xk1nImoagoSROECBfe0J1AFkyO+BNBSCewX0XdJEFGtgiaUvw8Ehnw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-21T18:49:58Z"
+    mac: ENC[AES256_GCM,data:bVTOoS0pXT2d7O6o1fugQ9wI9DTJq5QV3OcK1HZJ2clVzusQ05Dwib2vwvyxG8RsVsqM+PUIxgeUg8Cg699LNVomb4SV7IiIGj5lIjYsXlmEDYE6FeZxSjx2gioRqRu9j8gTVdnvFnZmszX+w9uTu88AWc09V1rZu1o9xznHRpA=,iv:v/+Ud9MnxDSv6kAR3hm+1JvNJYf+S0ujPoST4QRdnoU=,tag:ZjCjUZvBJxhMD7t0UhwJbQ==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.12.2

--- a/infrastructure/controllers/postgres/secrets.yaml
+++ b/infrastructure/controllers/postgres/secrets.yaml
@@ -1,41 +1,41 @@
-apiVersion: ENC[AES256_GCM,data:eAE=,iv:Nq49qDnsgWQb92x2q0QLACxy2/MqmTGxhiMdz9Zs8lQ=,tag:ui2Uk3QRhMmZncEzvA/bkA==,type:str]
-kind: ENC[AES256_GCM,data:WoMQkzMz,iv:4syrQZh8Vmsl3WnUtuWyvsv+1bl8zX8/vZ21mvsvaTI=,tag:maoZDYpokwlfzqGj53i/bA==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:ZhP5QhNgPYQawbiYDr0=,iv:49Cjzp9LveZNfYIe0vgoE/ANQpU9YBD49RQr5Ztz9sY=,tag:1k0kdwEPnb4/VYzoM9TyAw==,type:str]
-    namespace: ENC[AES256_GCM,data:MY9sEBebcv0=,iv:Dz557ULU2tBeSuEZxq6bbyThBj3qE7xBdW10AULpQss=,tag:rPiTA4li5wQlt+fLn/+DGA==,type:str]
+    name: postgres-admin
+    namespace: postgres
     annotations:
-        #ENC[AES256_GCM,data:0e0YeUjOOxaeyQNJDyM7z3AcbNgIGxFp7NoJgETuD0qLxnynKOOJYF8BlCYgth4eZEzrDia27Uhd+Zsr6UyPdiOa,iv:sLItmjHSYTFXZjyM6FrKTik0VzDpvacb6zcP5i/ctiI=,tag:aWzNuxEWBECqzRDMBKTuGA==,type:comment]
-        #ENC[AES256_GCM,data:hA2S6FGISiAReDjM8OqhtbNmQpSJ/cP/VbG2Edo1GoV7xjaLzbk6PYpGP0SIuEVz4PoTcYEgh1ubRv6sgA==,iv:markitWneKkq3iLLZQZcWiYHavZ1/PBRIkBQ30gTNG8=,tag:LYqoBOUjhOUmKNivvsTwIw==,type:comment]
-        #ENC[AES256_GCM,data:s+IyOb52it+ehivBbPeoByssiCr9a/FX/vsobnNrEtGGIKmvBgZIGKM3Q4dS4Kl+SeFqlVffExrk9Y5JqaHJ,iv:ggfQJUydaAP83US8bj50nWqnbK8rlRYs2bb1TBfa4lk=,tag:es3Y3Orrp6i1UI2Ev6HYtw==,type:comment]
-        #ENC[AES256_GCM,data:Hjvt4BzV6jlsCIduL3kIwwvIq1ttmEWQCe1Y3X7dZIJ6wJCjGSkGrlk=,iv:jagfDUJjn3p4dJyZMscEc7HjGkXr1x4znIkdFPdoY98=,tag:gU/Ec6L8a9uzfqwYD2vI1w==,type:comment]
-        reflector.v1.k8s.emberstack.com/reflection-allowed: ENC[AES256_GCM,data:sTspmg==,iv:vgj+2PETMyYXr7qiwr256sQrc+YxyJCB3xNAP+N0FLI=,tag:UR6YpXzPYnnrlQl034zT4g==,type:str]
-        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ENC[AES256_GCM,data:j2URjF8=,iv:4QYBVfh42nHdWLe4UG7kvVO3755vD+pNBATlauveo9c=,tag:fNRG2GWonLH61sKas+XqNA==,type:str]
-        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: ENC[AES256_GCM,data:b3W3xw==,iv:QHHBAKBLh94OBZQjyj+/NDYh6V9Wt6F0qNbK6ysfJ8g=,tag:lP85fqYSkPnEvGn9+BaT1A==,type:str]
-        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: ENC[AES256_GCM,data:VYNE0vw=,iv:DLB1lN1DxlPd6rzeETWK7a7A3c8T4ybXCpyrTVkHCmM=,tag:cqZCvEOJrVO+bvmMcn7BEA==,type:str]
-type: ENC[AES256_GCM,data:lPXidmMG,iv:t7i8w8nG2v1xHYh+arKRnD8JW3vPIwKX3HaflHnbvo8=,tag:f7/ByJVEkVYJIZDVdGckAQ==,type:str]
+        # Reflector mirrors this secret into app namespaces that need admin
+        # credentials for their one-shot init Jobs. Add each consuming
+        # namespace to both allow-lists (allowed is the ACL, auto is the
+        # active mirror list). Never widen to "*".
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: umami
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: umami
+type: Opaque
 stringData:
-    password: ENC[AES256_GCM,data:2nuHDJIBnW20QK1D/FBJfaUHLtnKsHC1,iv:3quQhhMk3p7g5jRKdXECe6Yv4tkZPgzHJa+vEWvvHl8=,tag:ARNXs8oq6a+GsGFeW/JQfA==,type:str]
+    password: ENC[AES256_GCM,data:vk7mIujtXfn5AMd4k2vTrUEyJlTkLWvQDklmqRFC/QdcWOqXzDoNQpjX527O9+fXAaLJ40+b3VjGVBV9yXBTww==,iv:rqiNt1QfR/HyHbtRut2nNWXdFmBcrxXXRy3ky+4EfWc=,tag:OC9RpdjP22RLQYulArotzg==,type:str]
 sops:
     age:
         - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZa21VNU45elJaTzBCSUIx
-            TFk1aUIvcGhjTnJnL3JDWDQ1Y0VBN3JGcmtVCjFwbEtXeDN5TFk3WnJxRjVNdG55
-            dEtXZ0tKQmdONUZxQmFELzNmMW0waHcKLS0tIG9RRUpJUHIzNVlwUldSS1RRL2JP
-            bWdFOHh6UGNZQVZ0b2hFNXowOGlab1kKdQJ7vB5PH+BSJrn6pZronj6FzsN7QEMi
-            dotQDv7yGQOr3N8gMUWg9aR6uko3fqgO7kevxbLgaEOZjV+rRFw4xA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBMVhBYTNteXVJTGFZaUUr
+            NzNHcmI2UlMrUS9DUytoRjhCMWd5M2VNU2hzClNnQUlGRlpZbXd1djh2Z3lZMDdD
+            Z091VnZXbGJZSzY5eURJM2xyeW5nSTAKLS0tIFIyYkhJR3RNMTcwOXhKeUVEN0dn
+            cnExaTlGR3NtbWJqQ0lGT2I5OUo2SkEKtglk9Pi9QxELT7qDgiasCIQ3itxMarNu
+            nNuNDw35gFkRvTZ+m9sqYtjYw7swqlBhlhI7icCodoiK0HUy2JlfLg==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGS1JQV1N6YVl0ZW9tUXRi
-            NURVSVd3K3I3cmJSM1NGam1hTDkwKzBYM0NrClpGanNaa2xpK21xOWhDSGFLOG9u
-            MlJrSFFDYjR5M2MvbzFKbzZYSzJ1UUEKLS0tIFNha1BCZExBUEZURlFvRFBtWHJz
-            bnI0bG52ajlGN0FTL0gvQVpDaTVyT1UKXp6s4xl9ivq7HpFb9Cc1pvoDJUanZRO2
-            Xk1nImoagoSROECBfe0J1AFkyO+BNBSCewX0XdJEFGtgiaUvw8Ehnw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTeWRXMVFDaGJwaXl2cXAr
+            aE1oRnYvcmdvOVo2MXptb0MzdzdRNWxSckZRCnZWWWhhaDhNcmp3bERxTmFaVUhk
+            UGFZaVdCNmFzQTMxNE8xdXlQQjZxU00KLS0tIGc2RThkSjBEVnRVdTkyZVJNbE0v
+            NlJhVzl3cVZuM29FTlNOSzBBWEZjVVUKSbIaF+whlBstNLSY3WXu6Rx9ZfZ8h5Tw
+            wFmktlChcNLZtjaIldzf7ZdZpWcdljVdn57XVIWFv8JQ7FmunL5Mcw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T18:49:58Z"
-    mac: ENC[AES256_GCM,data:bVTOoS0pXT2d7O6o1fugQ9wI9DTJq5QV3OcK1HZJ2clVzusQ05Dwib2vwvyxG8RsVsqM+PUIxgeUg8Cg699LNVomb4SV7IiIGj5lIjYsXlmEDYE6FeZxSjx2gioRqRu9j8gTVdnvFnZmszX+w9uTu88AWc09V1rZu1o9xznHRpA=,iv:v/+Ud9MnxDSv6kAR3hm+1JvNJYf+S0ujPoST4QRdnoU=,tag:ZjCjUZvBJxhMD7t0UhwJbQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-04-21T19:29:25Z"
+    mac: ENC[AES256_GCM,data:NdW+2aXH7SkYn1eAkDooBnWCXFOfiIFVZEG7YadvaGD00mcF5YyMw+xIEHvLwDHI5RGS2ZQMM/E4fKjj8RLUOcc9hMq4vgWKCclF+t4i7v1YcdYXUQFKZgmfuR29q44xWIJ9+pFlcw95WiZ6UdNxeKuDVtnnPTLWoPN+E7JGKGw=,iv:yp2IOUdAJZzJX+jUEwFpTUx7YC1nPijzNGXAyOs4TYo=,tag:6oIVQ03qJo8Gxb2UF1aaBg==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/infrastructure/controllers/postgres/service.yaml
+++ b/infrastructure/controllers/postgres/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: postgres
+spec:
+  selector:
+    app.kubernetes.io/name: postgres
+  ports:
+    - name: pg
+      port: 5432
+      targetPort: pg

--- a/infrastructure/controllers/reflector/kustomization.yaml
+++ b/infrastructure/controllers/reflector/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/reflector/namespace.yaml
+++ b/infrastructure/controllers/reflector/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reflector

--- a/infrastructure/controllers/reflector/release.yaml
+++ b/infrastructure/controllers/reflector/release.yaml
@@ -1,0 +1,33 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reflector
+  namespace: reflector
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: reflector
+      version: "10.0.35"
+      sourceRef:
+        kind: HelmRepository
+        name: emberstack
+        namespace: reflector
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Watches Secrets and ConfigMaps cluster-wide and mirrors those
+    # annotated for reflection into permitted namespaces. No CRDs; just
+    # annotations on the source Secret.
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/infrastructure/controllers/reflector/repository.yaml
+++ b/infrastructure/controllers/reflector/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: emberstack
+  namespace: reflector
+spec:
+  interval: 1h
+  url: https://emberstack.github.io/helm-charts

--- a/infrastructure/controllers/tailscale-operator/secrets.yaml
+++ b/infrastructure/controllers/tailscale-operator/secrets.yaml
@@ -1,32 +1,32 @@
-apiVersion: ENC[AES256_GCM,data:Aos=,iv:4IGAulxAtltBSw9XcwVwT7BcVQulMjaJR8ZEac7eCbE=,tag:s1uD4qfVpsVLqI+l4MZ7vg==,type:str]
-kind: ENC[AES256_GCM,data:PvTV9RrA,iv:lLsbYIOl+cEqKvhjbJo7GeFk1mUh9HWeHZE46TDpG68=,tag:apfUnHoDecRB3/NFZD3fgQ==,type:str]
+apiVersion: v1
+kind: Secret
 metadata:
-    name: ENC[AES256_GCM,data:2K6G6Kf3WFT65vccZ9cqQgpNSyPLlJS/,iv:sXfbIhHOkWB2JBrkSdxUooc5w8xvsq5FooQhhOceuhs=,tag:kmiqbruFSR6mUkB4vrnrJw==,type:str]
-    namespace: ENC[AES256_GCM,data:SXEG7WasPFe7,iv:gqv05pcGXhb6wvpBXz9111Dg/IwkB6kKOXBwhENh+/k=,tag:ifVNFOuD2bvfg/UVYZi4Eg==,type:str]
-type: ENC[AES256_GCM,data:xCP6dluB,iv:v+rwe8WxwW/38SPQoTzzMxFQrjx8WZZ6t6pHIk5b+qU=,tag:KJ/WKzHYtnpIZ4Ou6UwM4A==,type:str]
+    name: tailscale-operator-oauth
+    namespace: tailscale
+type: Opaque
 stringData:
-    values.yaml: ENC[AES256_GCM,data:4YXCEYlrNzuWNGSzjogetOzMA/g6aSqa5tYVoV4D7hf/dYbgbUqdnmn9i6XAxf09nGCcsKyoUIwKViyrvCZyT5gJ5BSn7ljQDzCjIYhmBnUol4hmML6vGeosbdWiTB2wxD16WYSTxJMukyZdgbnJqCw3B6ah,iv:2hHxRIVQJk3wV+1b1+HSdhQ0PSqQKeAHHXO4re29qbI=,tag:yhImJn6m6cv8B7q1RtD7iQ==,type:str]
+    values.yaml: ENC[AES256_GCM,data:yjXCFoA82Ij5CMu9tsU9zdOD7bNjGx+0Zn3b/v8mLpOxRD8gnE6KGXgoS0kGWAaGSxlTNqliC4byFEFQ4k27Na7N05LjYpXZBHU8I0n3mv2JuI68lBpLJEkJ1FgKFE0yJ5rf3SBLuh+K0H5j+JKdlkC+z4qF,iv:YfyJxFv0gj0/VtXpzpYQmmOzxPpFjXid41QSNHwppfE=,tag:QlEUyprnrxlHu/mWUNyLFg==,type:str]
 sops:
     age:
         - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkUkZ3UEFZSEZPYlNXWkZ5
-            Nkc5UTlPd0NqWVF0cjhDak5vcW1LZDhObDFZCm5UZHdEZDROVzY5VGliZVI2MlFk
-            UEdOdytwMXJmakI3NjZUN2dTZDlFSFkKLS0tIHhtd2VrYWJvTm8wdFhTUThyV2Fn
-            N3J2aDRBNjZvZGR6MzdWZS95Sy9KekkKJFQivyYqPll7f9kDziOfPPiDPBGR9nIh
-            u/gukoVKejy3C3OkYD4/5GYBXacrqd8+Ar/Nwjq+RVgXzRHR05/CsA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFOFBCR080RDRPd25zSVdV
+            bkZlcGZNRGNHWjRqMXdDVW0wZWRBR0hpeVZNCmZtMUVFQkNEUnduM01aLy9MdDhz
+            cGVNaGpwTW9PT1JxZWhxcnBweE55RUEKLS0tIHJlczJTVnhDeC96U3BKUFd5OWcy
+            ZitmblVySTRvR3pzeWNCT1RVU0ZzUTAK0TGuOwq7uT1JRb0yijyWhGzabfD7fmyM
+            sWCKtLBphkXcZrluY4PQc+Z/RW3zV4B8hkvNomaWDQFlblgxGY8MUA==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Z21CclNkZnFqdVpDYWVI
-            S3pIT2pZSnhkVk4wZVI3UG1PYWE1UUtlS1FjCldmT1oyOVNZejZXaDRYVXJSRWlT
-            bldtMUtXWW1pN2djTjB6NXAxRisyZ3MKLS0tIDQ1T1BGajNqUzhJV1VydHZCRmVT
-            REMwVWpQV0lQTmxNYjFMZDEzWE1RZ28KwA8gJzxlPbQYYq+iruOQdzwOHE8s4YRh
-            xnN1JCwtJawzhrMeh10TAADn8RMD3SplG+B5XeaYBWLveHNNoaA8eA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmL1hDeFo2bUhOcFd6K0JX
+            eFFHdEJLUkc4R1ZsMXJpV1dUZ2RpSStCK1dJClBDTmE4dlNZV003bXRuQkQ4Y29v
+            aTBNTWZRcFMzelU0aDhFcHlXU284M1kKLS0tIGxMNzBmQVdCd3Z3OHoxKy9KcFVU
+            RUpuQ1kwdllCa29LUnFGek45Z3lNWEEKK6LS+cu4zTXzGcxNp9ycI8I8zGERZYU5
+            k8LQv+/ckZG1eg51iDzAJERCj4lflyyroNpI9kyCAwzSjh3Zt7YEiA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T15:06:03Z"
-    mac: ENC[AES256_GCM,data:hv01usjztNR5PrlxOkgo0Y072q7zcHmFAQfdEPEb1rwZBGEQ9f06JnUnCin2ZBO3fxleAPwkQwrTf39flgE9uZpxlG5PD7KZhB14EJ6tf/i50bMvn/10T7e7VBcWOzdPWAbPSsRZkB8KzZPGnlxunqaVV8ja7DqG2J/l0mfTwvs=,iv:bLFOFSaXdT+j7BFX+/3vv89q6G1yxMB6248CBQUfVd0=,tag:XwnCM8fF7xutZ0eSc5rLfQ==,type:str]
-    unencrypted_suffix: _unencrypted
+    lastmodified: "2026-04-21T18:59:41Z"
+    mac: ENC[AES256_GCM,data:RfAiIEaBEZlbicj8sRjCWbsCuGBMAix0FuBUpqr1pTv991m19f/6xGbkLxdZV++Ajs2rnA8YaaHFYrlfmlaDfHiSjucYtnxNLraPj5TTaQmDoeH9sK4howE6nf+sEFwzXA/PorSGikpsyDx4WH1zZAEw66u6SXqCIy186GMsTHg=,iv:Z0Z/vUvNXNZCYa0xdJbEdYPzpumHOw14Q+p4EnZ25o4=,tag:DdsJ6Mxfsl6KNzGpS003RA==,type:str]
+    encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/opentofu/cloudflare.tf
+++ b/opentofu/cloudflare.tf
@@ -55,6 +55,16 @@ resource "cloudflare_record" "status" {
   comment = "Gatus uptime page"
 }
 
+resource "cloudflare_record" "analytics" {
+  zone_id = data.cloudflare_zone.farooqui.id
+  name    = "analytics"
+  type    = "A"
+  content = var.homelab_public_ip
+  proxied = true
+  ttl     = 1
+  comment = "Umami analytics"
+}
+
 # Authenticated Origin Pulls: CF presents a client cert signed by the
 # Origin Pull CA on every fetch; Traefik's TLSOption in the cluster
 # requires that client cert. Together these ensure only CF can speak


### PR DESCRIPTION
Deployment, operator side after merge:

1. Generate passwords:
   - `openssl rand -hex 32 > ~/.config/homelab/postgres-admin-password`
   - `openssl rand -hex 32 > ~/.config/homelab/umami-db-password`
   - `openssl rand -hex 32 > ~/.config/homelab/umami-app-secret`
2. `sops infrastructure/controllers/postgres/secrets.yaml` — paste the admin password.
3. `sops apps/umami/secrets.yaml` — paste the two umami values.
4. After first Umami login, create the farooqui.ai website in its UI and add `<script async src="https://analytics.farooqui.ai/script.js" data-website-id="<id>"></script>` to the Astro site.