### PR TITLE
fix(homelab): rotate r2 access keys

### DIFF
--- a/nixos/hosts/homelab/secrets.yaml
+++ b/nixos/hosts/homelab/secrets.yaml
@@ -1,7 +1,7 @@
 tailscale_auth_key: ENC[AES256_GCM,data:0cui7QM/iXBJSt/ivOtOU7zXGb5+Uhdo7s29M4v50kdoo7SSrtsINwst98Q0Srx/My0PQg6iAQpUBJc26g==,iv:GPlt/QbXmJWpJ3/0ILGVuRCeWGfVrZMJdeggExdwp4E=,tag:FwBJojX6syTQgVPw4uzkeQ==,type:str]
 r2_repository_url: ENC[AES256_GCM,data:xWkResAAs8Eqai5k7PiUuqz3YexV2SRM96WI+PaJKB79PzNyiu1I6rnodqhtPdAmRorpET6I6sx6zY40wrbei5ZpK2cQhs63y/OHCA==,iv:WFbW3VuSSUznujXM8XqTiSIwxV2qQWbn9Dib4evsm1A=,tag:C7ZPGV7pCDPRse/g1oN2mQ==,type:str]
-r2_access_key_id: ENC[AES256_GCM,data:IEaYIA6/zUxIkt3dnyf/Fjc8GBgr3oXQ0jHKcsYXk3Y=,iv:lOI28JzJlLFUPFqlL/wkDW96eJJ7yBTA1ErFzxrFwh4=,tag:r7WK+q6/ReuYvFpsBqet3w==,type:str]
-r2_secret_access_key: ENC[AES256_GCM,data:tWKg+FbsXGbZVqpVtqSlopupWCgzuHbIeSDFLIwc56RVURW2b4XLlxdiIvK4RNxluDspUGSIsbU9g+4WWwrOLg==,iv:m/AsZjl2uDGMpwHtxXM6VbBjjG7dE8QJ/RCX4PAmhkI=,tag:7mpZoKTL20EUxpG/9eIY2Q==,type:str]
+r2_access_key_id: ENC[AES256_GCM,data:BjuDjEk3FJcT0x6ALXoKC7r+LEPiUAR7ozrund8Abrs=,iv:BjMxIJbWwjtsEUJLrYYTEUxfPkVypcSxAv9VqKkfH34=,tag:5ldzcIHn54WGyJw49bXPlw==,type:str]
+r2_secret_access_key: ENC[AES256_GCM,data:i7PRY4HTvncyVl/sRxGL/FLYFgHzuG5BGjub+USmRO9Q4Aqg6Y5gCkOw/opf3XpJyK7QkjpV2CL/T0P11xKzPg==,iv:J1OAtQWBS4c0Nu9KDEodYYD7lMRW9TOWDC2GUdxbFQU=,tag:K0FCFvkZEYU68oLIHa3dVg==,type:str]
 restic_repo_password: ENC[AES256_GCM,data:B93LlUGm19ayR2CFrXEB74oS2nXwigdVXBr+XvnViX52iJCkkXLAJPilbqJ/qxuRhzynazBirs4bIwrdcX1X9A==,iv:877nuiFJ63x8Yr8acVg8vosQkyVOCsPBC57PDYPknWo=,tag:IJwTdoFks7aO23Jy71H2iA==,type:str]
 sops:
     age:
@@ -23,7 +23,7 @@ sops:
             U3lFR2FEc2x3aW5jdnMvRzBFYXQwdEEKw2lrCWqh3M+THaD6ULhga5kwO7JBbNXm
             3wH5CRpuvg80XrrB5vAS0Mwpg/vCzy7XTyCX4TBKvRZbHp+jUr/2Ig==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T10:29:56Z"
-    mac: ENC[AES256_GCM,data:I9lBm4o5fEl7H8IE05N5Qr+R09RbutqQXlRoLWB05Ij+v4N+TxsNWqSyYNW3xWcNKQLSXyWq0ATkXdiLLBJb3AXPL+uIUvb9clLEfYddyS0/jlWmFAHgwv5wrIN2qf4m77No1xwnd6D80ifpOo9huumbGVR9a+ajL0XSN1KQIu8=,iv:J3KQpsYLQ9ObEy18HSUDmZ+NaDBNXdcxe4KHTOxW+Xs=,tag:9wIi/gAshwaLio4aDetYgQ==,type:str]
+    lastmodified: "2026-04-21T20:00:45Z"
+    mac: ENC[AES256_GCM,data:q+AMwmmjQcHg/pfKaNbsIoOpb7eXBXoH3zbWXHFGLp7YveHZm20GVpkBRubhh8Tm62JLJOLpEmH7FhwSAZWGREuJdaiA0nrrfoufMIKKeFDHaKvXbe7jlPqDob9IuN5SHSBQdJ+E2qu3IbmvQPWRhTI46xxsrVTLS2qTB8d2onA=,iv:bJO/D3k8I7dftsj29AWXP/xACqftcoNVR9tzfh+2H4M=,tag:Idhc3vxF1y31dyDABo/LJQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Previous R2 access keys were revoked; host needs the new pair in sops for restic to keep writing to the homelab bucket.