### PR TITLE
fix(umami): use docker hub image path

### DIFF
--- a/apps/umami/deployment.yaml
+++ b/apps/umami/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: umami
-          image: ghcr.io/umami-software/umami:postgresql-v3.1.0
+          image: docker.io/umamisoftware/umami:3.1.0
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
ghcr.io/umami-software/umami doesn't exist; umami publishes to docker.io/umamisoftware/umami.