### PR TITLE
chore(polish): enable servicemonitors, bump site image, readme + envrc fixes

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -15,11 +15,11 @@ export TF_VAR_github_app_pem_path="$HOME/.config/homelab/REPLACE_ME.pem"
 # in .sops.yaml; the private half never leaves ~/.config/homelab/.
 export SOPS_AGE_KEY_FILE="$HOME/.config/homelab/sops-operator.key"
 
-# Cloudflare: API token consumed by the cloudflare tofu provider. Scopes
-# needed: Account > Workers R2 Storage:Edit, Zone:Read, Zone:DNS:Edit,
-# Zone:Zone Settings:Edit on farooqui.ai.
+# Cloudflare: API token consumed by the cloudflare tofu provider. Scopes:
+# Account > Workers R2 Storage: Edit; Zone > Zone: Read; Zone > DNS: Edit;
+# Zone > Zone Settings: Edit; Zone > SSL and Certificates: Edit on
+# farooqui.ai.
 export CLOUDFLARE_API_TOKEN="REPLACE_ME"
 
-# Homelab public IP: the Hetzner server's IPv4. Kept out of source so the
-# repo doesn't hardcode an IP a recruiter could port-scan.
+# Homelab public IP: the Hetzner server's IPv4.
 export TF_VAR_homelab_public_ip="REPLACE_ME"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -24,3 +24,7 @@ jobs:
         with:
           path: clusters/homelab
           enable-helm: "true"
+          # Tells helm template's capability check that ServiceMonitor is
+          # available (kube-prometheus-stack installs the CRDs at runtime;
+          # render with --skip-crds can't see them).
+          api-versions: "policy/v1/PodDisruptionBudget,monitoring.coreos.com/v1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![lint](https://github.com/shariq-farooqui/infra/actions/workflows/lint.yaml/badge.svg)](https://github.com/shariq-farooqui/infra/actions/workflows/lint.yaml)
 [![licence](https://img.shields.io/github/license/shariq-farooqui/infra?color=blue)](LICENSE)
 
-Declarative infrastructure for my single-node homelab. A Hetzner server running NixOS + k3s, reconciled from this repo by Flux. Public site at [farooqui.ai](https://farooqui.ai), status page at [status.farooqui.ai](https://status.farooqui.ai), tailnet-only Grafana for metrics and logs, restic snapshots to Cloudflare R2.
+Declarative infrastructure for my single-node homelab. A Hetzner server running NixOS + k3s, reconciled from this repo by Flux. Public site at [farooqui.ai](https://farooqui.ai), status page at [status.farooqui.ai](https://status.farooqui.ai), self-hosted Umami analytics for that site, tailnet-only Grafana for metrics and logs, and daily restic snapshots to Cloudflare R2.
 
 ## Layout
 

--- a/apps/personal-site/deployment.yaml
+++ b/apps/personal-site/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: personal-site
-          image: ghcr.io/shariq-farooqui/farooqui-ai/personal:0.1.0
+          image: ghcr.io/shariq-farooqui/farooqui-ai/personal:0.1.1
           ports:
             - name: http
               containerPort: 8080

--- a/infrastructure/controllers/cert-manager/release.yaml
+++ b/infrastructure/controllers/cert-manager/release.yaml
@@ -30,7 +30,7 @@ spec:
       replicaCount: 1
     cainjector:
       replicaCount: 1
-    # ServiceMonitor needs monitoring.coreos.com CRDs from
-    # kube-prometheus-stack; leaving it off until that stack lands.
     prometheus:
-      enabled: false
+      enabled: true
+      servicemonitor:
+        enabled: true

--- a/infrastructure/controllers/traefik/release.yaml
+++ b/infrastructure/controllers/traefik/release.yaml
@@ -61,15 +61,11 @@ spec:
         exposedPort: 443
         tls:
           enabled: true
-    # Prometheus metrics endpoint on the pod. The ServiceMonitor gets
-    # enabled once kube-prometheus-stack installs the monitoring.coreos.com
-    # CRDs; enabling it before then makes the Helm install abort on
-    # "You have to deploy monitoring.coreos.com/v1 first".
     metrics:
       prometheus:
         enabled: true
         serviceMonitor:
-          enabled: false
+          enabled: true
     logs:
       general:
         format: json


### PR DESCRIPTION
Three commits: enable cert-manager / Traefik ServiceMonitor now that kube-prometheus-stack's CRDs are in place (validate workflow gets an extra api-versions hint so the offline render clears the helm capability check); bump personal-site image to 0.1.1 (which carries the Umami tracker); mention analytics in the README and correct the Cloudflare scope list in .envrc.example.