### PR TITLE
feat(tls): tailnet wildcard dns and shared certificate

### DIFF
--- a/infrastructure/configs/cert-manager/README.md
+++ b/infrastructure/configs/cert-manager/README.md
@@ -1,0 +1,75 @@
+# TLS strategy
+
+Two certificate patterns coexist in the cluster.
+
+## Public services: per-host certificates
+
+Hosts served on the public internet (`farooqui.ai`, `www.farooqui.ai`,
+`status.farooqui.ai`, `analytics.farooqui.ai`) own their TLS. Each
+`Ingress` declares its own `spec.tls.secretName` and cert-manager
+issues a dedicated Let's Encrypt certificate per host via the
+`letsencrypt-prod` `ClusterIssuer` (DNS-01, Cloudflare). These
+Ingresses also pin the `cloudflare-origin-pull` `TLSOption`, so
+Traefik only completes the handshake for clients presenting the CF
+Origin Pull CA client cert — direct-IP requests fail at TLS.
+
+## Private services: shared wildcard, default TLSStore
+
+Tailnet-only services (anything reachable via the `*.farooqui.ai`
+Cloudflare wildcard pointing at the homelab's CGNAT tailnet IP)
+share a single `*.farooqui.ai` + `farooqui.ai` wildcard certificate.
+The wildcard lives in one Secret in the `traefik` namespace and is
+served via Traefik's default `TLSStore`; private Ingresses declare
+`tls.hosts` without a `secretName` and fall back to it.
+
+### Why a wildcard rather than per-host certs
+
+The decisive argument is **Certificate Transparency log hygiene**.
+Every certificate Let's Encrypt issues is published to public CT
+logs (crt.sh, merklemap, etc.) and is trivially scrapable. Issuing
+per-host certs for `paperless.farooqui.ai`, `immich.farooqui.ai`,
+`vaultwarden.farooqui.ai`, and so on would publish a hostname
+inventory of the homelab to the entire internet, regardless of the
+fact that those hosts resolve only to a tailnet address. A wildcard
+leaks only the apex pattern; the set of services behind it stays
+private.
+
+Secondary benefits:
+
+- **Smaller key-material surface.** One Secret, mounted into one
+  Deployment (Traefik). No reflector fan-out, no per-namespace copies.
+- **Fewer ACME calls.** A single DNS-01 challenge renews the whole
+  private surface, leaving plenty of headroom against Let's Encrypt
+  rate limits as more services come online.
+
+### The tradeoff
+
+Renewal is all-or-nothing: if cert-manager fails to renew the
+wildcard for long enough, every private service becomes untrusted
+simultaneously rather than degrading one at a time. This
+single-point-of-expiry is the real downside.
+
+Mitigation is observability. `PrometheusRule`s in
+`infrastructure/configs/observability/cert-expiry-alerts.yaml` watch
+every cert-manager `Certificate` and fire `warning` at 14 days
+remaining and `critical` at 3 days, plus a `CertificateNotReady`
+alert that catches issuance failures before expiry ever arrives.
+Alertmanager is currently disabled (single operator, alerts are
+visible in the Grafana Alerts pane); wire it to email/ntfy/Slack
+when the homelab graduates past "one human on call".
+
+### Blast radius if compromised
+
+A leaked wildcard key impersonates every private host. This is no
+worse than a leak in any per-service cert in the same cluster,
+because Traefik is the TLS terminator for all of them and would hold
+every key regardless. The wildcard concentrates the key in one
+namespace rather than smearing copies across every app.
+
+## Cert-manager version and issuer
+
+- cert-manager `v1.16.x` from the Jetstack chart, CRDs installed
+  inline with the release.
+- `letsencrypt-prod` `ClusterIssuer` using DNS-01 against
+  `farooqui.ai` via a scoped Cloudflare API token (Zone.DNS:Edit on
+  the farooqui.ai zone only).

--- a/infrastructure/configs/cert-manager/kustomization.yaml
+++ b/infrastructure/configs/cert-manager/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - secrets.yaml
   - cluster-issuer.yaml
+  - wildcard-certificate.yaml

--- a/infrastructure/configs/cert-manager/wildcard-certificate.yaml
+++ b/infrastructure/configs/cert-manager/wildcard-certificate.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: farooqui-ai-wildcard
+  namespace: traefik
+spec:
+  secretName: farooqui-ai-wildcard-tls
+  # Cover both the apex and any single-label subdomain. LE issues
+  # wildcards only via DNS-01, which the cluster-issuer is already
+  # configured for.
+  dnsNames:
+    - farooqui.ai
+    - "*.farooqui.ai"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  # Renew 30 days before expiry. Leaves headroom for a retry loop if
+  # DNS-01 propagation is sluggish without tripping the 14-day warning
+  # alert defined in infrastructure/configs/observability.
+  duration: 2160h  # 90d
+  renewBefore: 720h # 30d

--- a/infrastructure/configs/observability/cert-expiry-alerts.yaml
+++ b/infrastructure/configs/observability/cert-expiry-alerts.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager-expiry
+  namespace: observability
+spec:
+  groups:
+    - name: cert-manager-expiry
+      rules:
+        # Warning 14 days out: cert-manager's own renewBefore is 30d, so a
+        # firing alert means two weeks of renewal attempts have already
+        # failed. Worth investigating before it's urgent.
+        - alert: CertificateExpiringSoon
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < (14 * 24 * 3600)
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "TLS cert {{ $labels.name }} expires in under 14 days"
+            description: >
+              cert-manager Certificate {{ $labels.namespace }}/{{ $labels.name }}
+              expires at {{ $value | humanizeDuration }}. Automatic renewal
+              should have fired by now; check cert-manager logs and the
+              Cloudflare API token.
+        # Critical 3 days out: at this point public TLS is about to break.
+        - alert: CertificateExpiringCritical
+          expr: |
+            certmanager_certificate_expiration_timestamp_seconds - time() < (3 * 24 * 3600)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "TLS cert {{ $labels.name }} expires in under 3 days"
+            description: >
+              cert-manager Certificate {{ $labels.namespace }}/{{ $labels.name }}
+              is critically close to expiry. Issue a manual renewal or
+              investigate the ACME solver.
+        # Catches the opposite failure mode: cert-manager thinks the cert
+        # is healthy but the Ready condition flipped to False (bad DNS
+        # record, hit LE rate limit, etc.).
+        - alert: CertificateNotReady
+          expr: |
+            certmanager_certificate_ready_status{condition="False"} == 1
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Certificate {{ $labels.name }} is not Ready"
+            description: >
+              cert-manager reports {{ $labels.namespace }}/{{ $labels.name }}
+              as not Ready for 30 minutes. Likely an ACME solver error.

--- a/infrastructure/configs/observability/kustomization.yaml
+++ b/infrastructure/configs/observability/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - grafana-ingress.yaml
+  - cert-expiry-alerts.yaml

--- a/infrastructure/configs/traefik/kustomization.yaml
+++ b/infrastructure/configs/traefik/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: traefik
 resources:
   - tls-option.yaml
+  - tls-store.yaml
 secretGenerator:
   - name: cloudflare-origin-pull-ca
     files:

--- a/infrastructure/configs/traefik/tls-store.yaml
+++ b/infrastructure/configs/traefik/tls-store.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: TLSStore
+metadata:
+  name: default
+  namespace: traefik
+spec:
+  # When an Ingress declares `tls: [{hosts: [...]}]` without a
+  # `secretName`, Traefik falls back to this store's default
+  # certificate. The wildcard *.farooqui.ai cert lives here so every
+  # private (tailnet-only) Ingress serves valid TLS without touching
+  # cert-manager or reflector. Public Ingresses keep their per-host
+  # secretName and therefore bypass this default.
+  defaultCertificate:
+    secretName: farooqui-ai-wildcard-tls

--- a/opentofu/.terraform.lock.hcl
+++ b/opentofu/.terraform.lock.hcl
@@ -2,48 +2,46 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/cloudflare/cloudflare" {
-  version     = "5.18.0"
-  constraints = "~> 5.0"
+  version     = "4.52.7"
+  constraints = "~> 4.52"
   hashes = [
-    "h1:2FKT5YVLuHLmv7BnFxDC3UtipD3hSSrb0iJ9Ei2C/ks=",
-    "h1:6FoKYTGqaCvKctMEm1Y1c06mmY3I04jhCBRXEYe6mcQ=",
-    "h1:AhWro37kF118sAjRjIZ27CuV6kFpg1d+XYDo/7diyjU=",
-    "h1:B9eoAx4QKNVuKHDahNl8JzuSLCCeIGAJiS0MckJu5wQ=",
-    "h1:KfnaaT3RFoyWvPHsNVmsrCV7QEAGPLGNyHWT9IY+bxY=",
-    "h1:SPFFA6LxyFkjpEnpWbyQVyVJVXxzP8RLpehfUMRXDp4=",
-    "h1:VMUOof+Cf2h4asIe2lin7Fvf15mGWQ9mQYiuGhYM1aw=",
-    "h1:ny17Q/ce8iuHxppA/yIuRpCkVDtqhE+LDynWtv9/qwI=",
-    "zh:47e7bdfd8eddd2685f383269c0b6936ef62edd6d8383c8d7757b0cce0a689737",
-    "zh:aa23eb6aa128667883cabc449ceca4072d0181f574cd727e08ebd6d69a4bfd48",
-    "zh:c3da673e05d3bd933c82e2b6ba0f85aa23c5e24fadd3932f7c066314feeb65a3",
-    "zh:c59f07c017fc78b79e80554a0737c9db2a2e681c3e46ff637942d28d1f1a3924",
-    "zh:d559074612835a37fa684d8d7d0cf68911487b71f4067acc59069cb00bb8baf0",
-    "zh:e12290a4eda757c183a4258230245dd170f0def389c37eb771db144ce3b382dd",
-    "zh:ed47e484432ba1bbbb4802061f395ebd253ae8e20be9b72552d3d830fd2ca268",
-    "zh:f35e08d468408697b3e7c4a7f548b874141ac8f8d395ab8edded322201cc7047",
-    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+    "h1:pPItIWii5oymR+geZB219ROSPuSODPLTlM4S/u8xLvM=",
+    "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
+    "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
+    "zh:556a568a6f0235e8f41647de9e4d3a1e7b1d6502df8b19b54ec441f1c653ea10",
+    "zh:633ebbd5b0245e75e500ef9be4d9e62288f97e8da3baaa51323892a786d90285",
+    "zh:6acfe60cf52a65ba8f044f748548d2119e7f4fd7f8ebcb14698960d87c68f529",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:904acc31ebb9d6ef68c792074b30532ee61bf515f19e0a3c75b46f126cca1f13",
+    "zh:a1d0a81246afc8750286d3f6fe7a8fbe6460dd2662407b28dbfbabb612e5fa9d",
+    "zh:a41a36fe253fc365fe2b7ffc749624688b2693b4634862fda161179ab100029f",
+    "zh:a7ef269e77ffa8715c8945a2c14322c7ff159ea44c15f62505f3cbb2cae3b32d",
+    "zh:b01aa3bed30610633b762df64332b26f8844a68c3960cebcb30f04918efc67fe",
+    "zh:b069cc2cd18cae10757df3ae030508eac8d55de7e49eda7a5e3e11f2f7fe6455",
+    "zh:b2d2c6313729ebb7465dceece374049e2d08bda34473901be9ff46a8836d42b2",
+    "zh:db0e114edaf4bc2f3d4769958807c83022bfbc619a00bdf4c4bd17faa4ab2d8b",
+    "zh:ecc0aa8b9044f664fd2aaf8fa992d976578f78478980555b4b8f6148e8d1a5fe",
   ]
 }
 
 provider "registry.opentofu.org/integrations/github" {
-  version     = "6.11.1"
+  version     = "6.12.0"
   constraints = "~> 6.11"
   hashes = [
-    "h1:Hqvebe3Zc19DxRCHHLIByBvxCm+WJqGyAyYCbJDuHGE=",
-    "zh:0a5262b033a30d8a77ebf844dc3afd7e726d5f53ac1c9d4072cf9157820d1f73",
-    "zh:437236181326f92d1a7c56985b2ac3223efd73f75c528323b90f4b7d1b781090",
-    "zh:49a12c14d1d3a143a124ba81f15fbf18714af90752c993698c76e84fa85da004",
-    "zh:61eaf17b559a26ca14deb597375a6678d054d739e8b81c586ef1d0391c307916",
-    "zh:7f3f1e2c36f4787ca9a5aeb5317b8c3f6cc652368d1f8f00fb80f404109d4db1",
-    "zh:85a232f2e96e5adafa2676f38a96b8cc074e96f715caf6ee1d169431174897d2",
-    "zh:979d005af2a9003d887413195948c899e9f5aba4a79cce1eed40f3ba50301af1",
-    "zh:b8c8cd3254504d2184d2b2233ad41b5fdfda91a36fc864926cbc5c7eee1bfea3",
-    "zh:d00959e62930fb75d2b97c1d66ab0143120541d5a1b3f26d3551f24cb0361f83",
-    "zh:d0b544eed171c7563387fe87f0af3d238bb3804798159b4d0453c97927237daf",
-    "zh:ecfa19b1219aa55b1ece98d8cff5b1494dc0387329c8ae0d8f762ec3871fb75d",
-    "zh:f2c99825f38c92ac599ad36b9d093ea0c0d790fd0c02e861789e14735a605f86",
-    "zh:f33b5abe14ad5fb9978da5dbd3bc6989f69766150d4b30ed283a2c281871eda3",
-    "zh:f6c2fe9dd958c554170dc0c35ca41b60fcc6253304cde0b9941c5c872b18ac54",
+    "h1:Ggo6UCbR2gIuSiH6P3X9OWhd7Cgz+4kz/mjOn/AhF2E=",
+    "zh:0748f95426c7ef9f2a4759dc5b7727796cfdf4358f9fcf0db4c7b26c476708c3",
+    "zh:074bb3ba19fe340a5d3c220c9cdbb98344000566a5b201fbf95b57d7f8f99e70",
+    "zh:0c930ef5e64c15318251605c75b5417fdc20cf86e1b3eed107d2a07c76504125",
+    "zh:1a0ba200992cc4fead56861acfad9c53d5c012fcd2b386d797d86aa6828984f8",
+    "zh:447adaa0b2e314643517ef4312be0a5381356891bffd9d09fe9749006d08a77d",
+    "zh:47b37afbd73240f26f211a92c46950cb01d44b6f0090279b5611b5f849c98f2e",
+    "zh:53ac39084a384b30d986e9dbbdb3c8fb584ab6962ea7dfdfdcfb8a0d4fb3e7cb",
+    "zh:5a28e6eae849c30308a2b76dc7504051eb57e872aefe4c82596343466be5087d",
+    "zh:6fe48c6da41755d16e6f91c6937908e074c53f16f3b27a2c64e396ad19ed1337",
+    "zh:a2e02cdecb7c411274df1785d07ddca350254cacb5702d793517efe8744b9891",
+    "zh:b393080029ec1e44a9f4fa5c19388ec54c4d811666b325fddf71c4b8b04d47af",
+    "zh:be2d0a4518259238933fc592fedda2758ca6a31996a0bbc55fb7f694d07a2de0",
+    "zh:def6ef3bec386e46019618b3760a647199a467abd0302f8f8705417856756c6e",
     "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
   ]
 }

--- a/opentofu/cloudflare.tf
+++ b/opentofu/cloudflare.tf
@@ -65,6 +65,24 @@ resource "cloudflare_record" "analytics" {
   comment = "Umami analytics"
 }
 
+# Wildcard for tailnet-only services. Points at the homelab's CGNAT
+# tailnet address, so every subdomain not explicitly declared above
+# resolves to 100.x.y.z. Off-tailnet devices get an unroutable IP and
+# the connection times out; tailnet devices reach Traefik via
+# WireGuard. Explicit A records (apex, www, status, analytics) take
+# DNS precedence over this wildcard, so public services continue to
+# flow through Cloudflare's proxy. Not proxied because CF won't
+# forward to a non-routable origin.
+resource "cloudflare_record" "wildcard_tailnet" {
+  zone_id = data.cloudflare_zone.farooqui.id
+  name    = "*"
+  type    = "A"
+  content = var.homelab_tailnet_ip
+  proxied = false
+  ttl     = 1
+  comment = "Tailnet-only services (fallback for unlisted subdomains)"
+}
+
 # Authenticated Origin Pulls: CF presents a client cert signed by the
 # Origin Pull CA on every fetch; Traefik's TLSOption in the cluster
 # requires that client cert. Together these ensure only CF can speak

--- a/opentofu/providers.tf
+++ b/opentofu/providers.tf
@@ -8,7 +8,10 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
+      # Pinned to v4 until cloudflare.tf is migrated to v5 syntax
+      # (cloudflare_record → cloudflare_dns_record, zone data source
+      # changes, etc.). Tracked as a follow-up.
+      version = "~> 4.52"
     }
   }
 }

--- a/opentofu/variables.tf
+++ b/opentofu/variables.tf
@@ -17,3 +17,8 @@ variable "homelab_public_ip" {
   type        = string
   description = "Public IPv4 of the homelab's Hetzner host. Referenced by Cloudflare A records for farooqui.ai subdomains. Set via TF_VAR_homelab_public_ip in .envrc so the value doesn't land in source."
 }
+
+variable "homelab_tailnet_ip" {
+  type        = string
+  description = "Tailnet (100.x.y.z) IPv4 of the homelab host. Backs the wildcard farooqui.ai record so private services resolve to a CGNAT address only routable from the tailnet. Set via TF_VAR_homelab_tailnet_ip in .envrc."
+}


### PR DESCRIPTION
Adds an unproxied `*.farooqui.ai` record pointing at the homelab's
CGNAT tailnet IP, a single matching TLS certificate in the traefik
namespace, and a default TLSStore so every tailnet-only Ingress
serves valid TLS by declaring tls hosts without a secretName. Public
records and per-host certs for apex, www, status and analytics are
unchanged. A README under `configs/cert-manager` covers the
CT-log hygiene reasoning and the expiry SPoF mitigated by new
PrometheusRules at 14d, 3d and on NotReady.

Pins the cloudflare provider back to `~> 4.52` pending #19; the v5
constraint from #17 broke every resource because the code never
migrated.

## Verified

`tofu apply` against prod added only `cloudflare_record.wildcard_tailnet`.