### PR TITLE
feat(llm): local inference via llama-swap and llama.cpp on CPU

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - personal-site
   - gatus
   - umami
+  - llm

--- a/apps/llm/README.md
+++ b/apps/llm/README.md
@@ -1,0 +1,137 @@
+# llm
+
+OpenAI-compatible local inference via
+[llama-swap](https://github.com/mostlygeek/llama-swap) fronting
+[llama.cpp](https://github.com/ggml-org/llama.cpp). Served on
+`llm.farooqui.ai`, tailnet-only.
+
+## Why this stack on this hardware
+
+The homelab host is an Intel i7-8700 (Coffee Lake, 6c/12t, AVX2 only,
+no AVX-512, no AMX) with 128 GB DDR4 and no discrete GPU. The UHD
+630 iGPU has no meaningful compute budget for LLM inference and
+shares the same DRAM bandwidth as the CPU, so neither SYCL nor
+OpenVINO is worth the ops surface. llama.cpp's pure-CPU path is the
+correct target.
+
+Memory bandwidth, not capacity, is the dominant constraint on this
+platform: dual-channel DDR4-2666 peaks around 40 GB/s, which caps
+generation throughput at roughly `bandwidth / active_weights`. That
+is why the primary model is **Qwen3.6-35B-A3B** (Mixture of Experts,
+35B total parameters, 3B active per token) rather than a comparable
+dense model: only the active 3B are streamed through memory per
+decode step.
+
+## Model lineup
+
+| Profile | Model | Quant | On-disk | Use |
+|---|---|---|---|---|
+| `qwen3.6-35b-a3b` | Qwen3.6-35B-A3B MoE | Q4_K_M | ~21 GB | Primary; ~12-18 tok/s on CPU |
+| `qwen3.6-27b` | Qwen3.6-27B dense | Q5_K_M | ~20 GB | Quality-first, slow (~2 tok/s) |
+| `qwen3.5-9b` | Qwen3.5-9B dense | Q5_K_M | ~6.5 GB | Interactive mid-tier |
+| `qwen3.5-4b` | Qwen3.5-4B dense | Q5_K_M | ~3 GB | Quick completions |
+| `qwen3.5-0.8b` | Qwen3.5-0.8B dense | Q6_K | ~0.8 GB | Drafts, titles, agent scaffolding |
+| `gemma4-e4b` | Gemma 4 E4B instruct | Q5_K_M | ~6 GB | Google family mid |
+| `gemma4-e2b` | Gemma 4 E2B instruct | Q6_K | ~4 GB | Google family small |
+
+Quant choice skews higher than the "just fit in RAM" default because
+capacity is plentiful here; the bandwidth ceiling dominates regardless
+of quant, so going from Q4 to Q5/Q6 costs little additional time and
+noticeably improves quality.
+
+## Sampler and thinking-mode defaults
+
+Every profile starts with `--chat-template-kwargs '{"enable_thinking":
+false}'`. Qwen3.6 and Gemma 4 default thinking on in their chat
+templates, which burns response tokens on a reasoning monologue and
+returns empty `content` on small `max_tokens` calls. Defaulting off
+means basic chat requests return clean answers; enable thinking per
+request when wanted:
+
+```json
+{
+  "model": "qwen3.6-35b-a3b",
+  "messages": [...],
+  "chat_template_kwargs": {"enable_thinking": true}
+}
+```
+
+llama.cpp's server honours request-level `chat_template_kwargs` and
+overrides the CLI default.
+
+Sampler flags in `configmap.yaml` follow Unsloth's published
+recommendations for **non-thinking / instruct mode**:
+
+- **Qwen3.6 and Qwen3.5** (instruct, general): temp 0.7, top_p 0.8,
+  top_k 20, min_p 0.0, presence_penalty 1.5, repeat_penalty 1.0.
+- **Gemma 4**: temp 1.0, top_p 0.95, top_k 64, repetition penalty
+  disabled.
+
+API clients override any sampler per request. A `temperature: 0`
+field wins over the server default, so deterministic calls work
+without restarting anything.
+
+## Swap behaviour
+
+`ttl: 600` unloads a model after 10 minutes of idleness. The next
+request pays a cold-start cost (~20-40 s for the big MoE, seconds for
+the small models) while llama-swap starts a new llama-server
+subprocess and mmaps the weights. Active models stay resident as long
+as requests keep arriving within the TTL window.
+
+## First-boot model sync
+
+The `model-sync` initContainer reads the idempotent shell script in
+`model-sync.yaml` and pulls each GGUF via `uvx hf download` if
+missing. The first Deployment roll blocks until ~60 GB downloads;
+subsequent restarts are instant. Re-running after adding a new model
+to the script downloads only the additions.
+
+`HF_HUB_ENABLE_HF_TRANSFER=1` flips on the chunked parallel
+downloader for roughly 2x throughput on a gigabit link.
+
+### Wiring HF_TOKEN
+
+Anonymous downloads work but hit HF's free-tier bandwidth. To use a
+Pro token:
+
+```sh
+# 1. Paste the token into the plaintext template (read scope is
+#    enough for GGUF downloads).
+$EDITOR apps/llm/secrets.yaml
+
+# 2. Encrypt in place. .sops.yaml already covers apps/*/secrets.ya?ml
+#    and restricts encryption to data/stringData fields, leaving the
+#    outer manifest structure parseable by kustomize and flux-local.
+sops --encrypt --in-place apps/llm/secrets.yaml
+
+# 3. Uncomment `- secrets.yaml` in apps/llm/kustomization.yaml, then
+#    git add both files and commit. Flux decrypts via its sops-age key
+#    at reconcile time and the pod picks up HF_TOKEN on next restart.
+```
+
+## Verifying
+
+```bash
+kubectl -n llm get pods -w
+# wait for initContainer model-sync to finish and llama-swap to go Ready
+
+# health
+curl -sS https://llm.farooqui.ai/health
+
+# list models
+curl -sS https://llm.farooqui.ai/v1/models | jq
+
+# chat (triggers cold-start of the named profile; start with the
+# tiny one to prove the path before loading the 35B MoE)
+curl -sS https://llm.farooqui.ai/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{
+        "model": "qwen3.5-0.8b",
+        "messages": [{"role":"user","content":"In one sentence, what is k3s?"}],
+        "max_tokens": 120
+      }' | jq -r '.choices[0].message.content'
+```
+
+From off-tailnet the DNS resolves to the CGNAT address and the TLS
+handshake never completes.

--- a/apps/llm/configmap.yaml
+++ b/apps/llm/configmap.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: llama-swap-config
+  namespace: llm
+data:
+  config.yaml: |
+    # llama-swap proxy config. Every model below is a named profile
+    # that llama-swap starts on demand when an OpenAI-compatible
+    # request names it, then unloads after `ttl` seconds of idleness.
+    #
+    # Thinking mode defaults off for every profile. Qwen3.6 and
+    # Gemma 4 default thinking on in their chat templates, which
+    # burns response tokens on a reasoning monologue and surprised
+    # smaller max_tokens calls with empty content. Clients enable
+    # thinking per request with:
+    #   "chat_template_kwargs": {"enable_thinking": true}
+    # in the /v1/chat/completions body; the server honours request-
+    # level chat_template_kwargs and overrides the CLI default.
+    #
+    # Sampler defaults follow Unsloth's published per-family
+    # settings for non-thinking mode; every sampler field is also
+    # client-overridable (temperature=0 in a request wins over
+    # --temp here).
+    healthCheckTimeout: 300
+    logLevel: info
+    startPort: 10001
+
+    # Shared llama-server flags. Threads match the i7-8700's physical
+    # cores (6); threads-batch uses HT (12) since prompt eval is
+    # compute-bound and benefits. KV cache is Q8 per Unsloth guidance
+    # to cut memory without measurable quality loss, and mlock+no-mmap
+    # pins weights so the first token isn't stalled by page faults.
+    macros:
+      llama-server-base: >-
+        /app/llama-server
+        --host 127.0.0.1 --port ${PORT}
+        --threads 6 --threads-batch 12
+        --flash-attn
+        --mlock --no-mmap
+        --cache-type-k q8_0 --cache-type-v q8_0
+        --jinja
+        --chat-template-kwargs {"enable_thinking":false}
+
+    models:
+      # Primary: Qwen3.6 MoE. 35B total, 3B active per token, so CPU
+      # inference moves ~2 GB through memory per step — the one big
+      # model that's genuinely usable on a CPU-only homelab.
+      qwen3.6-35b-a3b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/Qwen3.6-35B-A3B-Q4_K_M.gguf
+          --ctx-size 32768
+          --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
+          --presence-penalty 1.5 --repeat-penalty 1.0
+        ttl: 600
+
+      # Dense Qwen3.6-27B. Better single-shot quality than the MoE on
+      # precise tasks but ~5x slower on this CPU; keep around for
+      # quality-first calls and be ready to wait.
+      qwen3.6-27b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/Qwen3.6-27B-Q5_K_M.gguf
+          --ctx-size 16384
+          --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
+          --presence-penalty 1.5 --repeat-penalty 1.0
+        ttl: 600
+
+      # Dense Qwen3.5-9B. Fast enough for interactive use.
+      qwen3.5-9b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/Qwen3.5-9B-Q5_K_M.gguf
+          --ctx-size 32768
+          --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
+          --presence-penalty 1.5 --repeat-penalty 1.0
+        ttl: 600
+
+      qwen3.5-4b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/Qwen3.5-4B-Q5_K_M.gguf
+          --ctx-size 32768
+          --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
+          --presence-penalty 1.5 --repeat-penalty 1.0
+        ttl: 600
+
+      qwen3.5-0.8b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/Qwen3.5-0.8B-Q6_K.gguf
+          --ctx-size 32768
+          --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
+          --presence-penalty 1.5 --repeat-penalty 1.0
+        ttl: 600
+
+      # Gemma 4 general defaults from Google/Unsloth: temp 1.0,
+      # top_p 0.95, top_k 64. Repetition penalty stays disabled
+      # unless loops appear.
+      gemma4-e4b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/gemma-4-e4b-it-Q5_K_M.gguf
+          --ctx-size 32768
+          --temp 1.0 --top-p 0.95 --top-k 64
+        ttl: 600
+
+      gemma4-e2b:
+        cmd: >-
+          ${llama-server-base}
+          --model /models/gemma-4-e2b-it-Q6_K.gguf
+          --ctx-size 32768
+          --temp 1.0 --top-p 0.95 --top-k 64
+        ttl: 600

--- a/apps/llm/deployment.yaml
+++ b/apps/llm/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-swap
+  namespace: llm
+  labels:
+    app.kubernetes.io/name: llama-swap
+spec:
+  replicas: 1
+  strategy:
+    # Recreate so the old pod releases the single ReadWriteOnce PVC
+    # before the new one starts. RollingUpdate would deadlock.
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: llama-swap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: llama-swap
+    spec:
+      # The init pulls GGUFs via uvx; the script is idempotent so
+      # restarts after a partial sync resume where they left off.
+      # First boot with all seven models downloads ~60 GB and can
+      # take tens of minutes on a gigabit link with hf_transfer on.
+      initContainers:
+        - name: model-sync
+          image: ghcr.io/astral-sh/uv:python3.12-alpine
+          command: ["sh", "/scripts/sync.sh"]
+          env:
+            # uv's cache needs a writable HOME; the default /root is
+            # fine since the pod uses an emptyDir there.
+            - name: HOME
+              value: /home/uv
+            # HF Pro token unlocks higher download bandwidth. Source
+            # is sops-encrypted; reconciled by flux's kustomize
+            # controller into a plain Secret at apply time. Marked
+            # optional so the pod still rolls before secrets.yaml is
+            # populated; hf download falls back to anonymous.
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: huggingface-token
+                  key: token
+                  optional: true
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: sync-script
+              mountPath: /scripts
+            - name: uv-home
+              mountPath: /home/uv
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      containers:
+        - name: llama-swap
+          image: ghcr.io/mostlygeek/llama-swap:cpu
+          args:
+            - "-config"
+            - "/config/config.yaml"
+            - "-listen"
+            - "0.0.0.0:8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # llama.cpp NUMA hint: benign on single-socket desktop CPUs
+            # and keeps behaviour consistent if the host ever moves to
+            # a multi-socket box.
+            - name: LLAMA_ARG_NUMA
+              value: "distribute"
+          resources:
+            requests:
+              # This pod is the heaviest workload on the node by a
+              # wide margin; reserve enough CPU and RAM to reflect
+              # the typical loaded-model working set rather than
+              # idle llama-swap (~50 MB, 0.01 CPU).
+              cpu: "2"
+              memory: 16Gi
+            # No CPU limit: inference is compute-bound and any ceiling
+            # throttles tok/s directly. Memory limit caps the biggest
+            # expected working set (Qwen3.6-35B-A3B Q4 at 32k ctx is
+            # ~26 GB resident with Q8 KV cache) plus headroom for
+            # swap-in while the next model loads.
+            limits:
+              memory: 64Gi
+          readinessProbe:
+            # llama-swap always serves /v1/models regardless of whether
+            # any model is loaded, so it's a stable liveness signal.
+            httpGet:
+              path: /v1/models
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: config
+              mountPath: /config
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: models
+        - name: config
+          configMap:
+            name: llama-swap-config
+        - name: sync-script
+          configMap:
+            name: model-sync-script
+            defaultMode: 0o755
+        - name: uv-home
+          emptyDir:
+            sizeLimit: 2Gi

--- a/apps/llm/ingress.yaml
+++ b/apps/llm/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: llama-swap
+  namespace: llm
+spec:
+  ingressClassName: traefik
+  # No secretName: Traefik falls back to the wildcard cert in its
+  # default TLSStore (infrastructure/configs/traefik/tls-store.yaml).
+  # No CF origin-pull TLSOption either: this host is served over the
+  # tailnet wildcard DNS record, not through Cloudflare, so the
+  # public-origin mTLS requirement would reject every tailnet request.
+  tls:
+    - hosts:
+        - llm.farooqui.ai
+  rules:
+    - host: llm.farooqui.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: llama-swap
+                port:
+                  number: 80

--- a/apps/llm/kustomization.yaml
+++ b/apps/llm/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: llm
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - configmap.yaml
+  - model-sync.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - secrets.yaml

--- a/apps/llm/model-sync.yaml
+++ b/apps/llm/model-sync.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-sync-script
+  namespace: llm
+data:
+  sync.sh: |
+    #!/bin/sh
+    # Idempotent GGUF downloader: for each model below, check the
+    # target file on the PVC; if missing, fetch from Hugging Face via
+    # uvx (no install step, ephemeral venv managed by uv). Runs as an
+    # initContainer on the llama-swap Deployment, so pod restarts are
+    # free but the first boot has to download ~60 GB.
+    #
+    # HF_TOKEN (sops-encrypted secret, mounted as env) unlocks PRO
+    # download speeds; hf download picks it up automatically.
+    # HF_HUB_ENABLE_HF_TRANSFER turns on the chunked parallel
+    # downloader, roughly doubling throughput on a gigabit link.
+    set -eu
+    cd /models
+
+    export HF_HUB_ENABLE_HF_TRANSFER=1
+
+    download() {
+      repo="$1"
+      file="$2"
+      if [ -f "$file" ]; then
+        echo "$file already present"
+        return
+      fi
+      echo "Downloading $file from $repo"
+      uvx --with hf_transfer --from huggingface_hub \
+        hf download "$repo" "$file" --local-dir /models
+    }
+
+    download unsloth/Qwen3.6-35B-A3B-GGUF Qwen3.6-35B-A3B-Q4_K_M.gguf
+    download unsloth/Qwen3.6-27B-GGUF     Qwen3.6-27B-Q5_K_M.gguf
+    download unsloth/Qwen3.5-9B-GGUF      Qwen3.5-9B-Q5_K_M.gguf
+    download unsloth/Qwen3.5-4B-GGUF      Qwen3.5-4B-Q5_K_M.gguf
+    download unsloth/Qwen3.5-0.8B-GGUF    Qwen3.5-0.8B-Q6_K.gguf
+    download unsloth/gemma-4-e4b-it-GGUF  gemma-4-e4b-it-Q5_K_M.gguf
+    download unsloth/gemma-4-e2b-it-GGUF  gemma-4-e2b-it-Q6_K.gguf
+
+    echo "All models present:"
+    ls -lh /models

--- a/apps/llm/namespace.yaml
+++ b/apps/llm/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: llm

--- a/apps/llm/pvc.yaml
+++ b/apps/llm/pvc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: models
+  namespace: llm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      # GGUFs are large but bounded. Current manifest (Qwen3.6-27B,
+      # Qwen3.6-35B-A3B, three Qwen3.5 sizes, two Gemma 4 variants) totals
+      # ~60 GB at the chosen quants; 100 GB leaves room for a couple of
+      # swaps or a higher quant without resizing the PVC.
+      storage: 100Gi

--- a/apps/llm/secrets.yaml
+++ b/apps/llm/secrets.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: huggingface-token
+    namespace: llm
+type: Opaque
+stringData:
+    #ENC[AES256_GCM,data:VgkkYAFOOMxzjiN1i+mjyZMpYgXj0TmReatWi1TFlb1EDj340PebaLx8SegGwjFOSGRexi0Qk2USL1VU2I1PbIM=,iv:bxaq2NViSm89M4Twk6e0d7AGpsCmCC2VvOgt0IPxF6A=,tag:vSKPijPOGavW7/ejZ9ZkiA==,type:comment]
+    #ENC[AES256_GCM,data:ILtiHuUY4ajJRQ3lvhyRKlkS3O6GaOGNT0z/HCQ42vMQmdGPUbnWGMZF,iv:iBg+a5/b1bEIqREZONnK4XzpoEsMExq2BIH3QLD7gA4=,tag:GMhlbjrzNzGbf+VpU/2jGw==,type:comment]
+    #ENC[AES256_GCM,data:njxaZIlydB0LZPuJXEgGH8/y396HMJZkTHAxcXWyZBPvekzpU9J8tqUwzH8L62/zl5g=,iv:QOVn/rDBasHbw3V+HIaieN+ncbekH2JMDqCsEgqctrQ=,tag:Ojnp4l5dxDm3ee1jnVQJgg==,type:comment]
+    #ENC[AES256_GCM,data:r+DYnemC5A+/8TziUzOTHmP2geuIwYcGKJU6W/ytaKu4D5sU9brRBwGDAeGP8vEoGoTcImiQgybIjVer9M7zZQ==,iv:BO8JKWPjAv4nBkD1WLLq4woY0cFrAB1JjN3TFtekidI=,tag:TQpScfsmUjnl4t26YVWxiQ==,type:comment]
+    #ENC[AES256_GCM,data:T9z+9hLyUNTqQfpDKggZFo68SOEgd/Ub4qSZ/4zuXnjB,iv:QHS5/NTs9Qhx4nmqxhJ9Fj3rvGur2k/G2wVJopoqN9A=,tag:NsUFHx8DoMqc154Si9kxqg==,type:comment]
+    token: ENC[AES256_GCM,data:lVqMnHw9dvpm7Gd2kN5q8gvRMoJCyy2YUoMFvPaqDUh8wvKGKw==,iv:y1FaGlT4SMlShpFLdopEZO1X4c/ocD+lZbwwiGQZ3DU=,tag:aXBfDzJD84IM0lRp8tWH5g==,type:str]
+sops:
+    age:
+        - recipient: age14gl7ry2n8ugwfhfjsd6gn0egsyxhf9yudpavqm0h8saw6yuuvgqsvkr5sl
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCOHphQ2d1NlZMWSt1QlVx
+            dU1YeXMxY1k4R1RZQms3eCtzUzhwRjNOTWgwCkpBOUZwZytLSkpmWTM5S3hIc0JV
+            T2kzVmVHRW04Ykh5WUZaWUE2UnRYZncKLS0tIGptQ3U0YTZheS9iQkFqR1NEdHFO
+            TmovS0lQdG5Lb3BvMExLY0dTNll2KzQK2YLR3DFw77M7WYB+IU029o5tSqwgf2mb
+            xO/tSNI7SuoO5nJeCDre2Wssn+GEmbpfILVU3fjrDqw4SnpiN8x6Jg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age17zy9ynlrmqcs4u03hh2echldh7utle2pxs62g4hzrvl7eswyqyuqt8hra9
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJVmE3eFkwZ2tZS1dLUnd0
+            QXZRNitVSnJpb2lVeDM0eDdjZDZSRHJaSEZRCmtZUEs2alRYYVgrYllRNnFHOW41
+            aHk1V2FMcysra3UvRzQ1T1FLWUNqaWcKLS0tIHh1QVhNVzdaVnlWTXVVRklqczk5
+            THNiV1VyVDBTYm5kUTBtL0VpeHluWjQKgGZR+2Mwv0k04AUYaLjMrnxvCyqRPZDO
+            AdA7iVyskdM8+CoH6lunLb5ZWeYUk5qzLOKmCP42LdVzwwGc/hY1aw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-04-24T11:53:41Z"
+    mac: ENC[AES256_GCM,data:Pwx3nRvuMTnbvREJwRehibMEkU6d7ZXwdg7aiLIYwEgwliA5qA4zQfOuK2vT/8whX0XZVAPFL+ZE1xpU5YYivgx0u8ZkKAeZAvlQoJeOOPX2jeKMuw9du8veNi9D2cfGe+dfCn3OBhOK4B8l/ouB0os2FoU7GuUm0jqJ+gE606k=,iv:6+hD6l0EDilhFogUzTWzRUuFTWY1yaADG+GPmm03ZtM=,tag:sFBCV5GETgba3ekmZo3u+A==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/apps/llm/service.yaml
+++ b/apps/llm/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-swap
+  namespace: llm
+spec:
+  selector:
+    app.kubernetes.io/name: llama-swap
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
New `apps/llm` module pairs [llama-swap](https://github.com/mostlygeek/llama-swap)
with a CPU llama.cpp at `llm.farooqui.ai` (tailnet-only via the
wildcard). Seven GGUF profiles cover Qwen3.6 27B and 35B-A3B, three
Qwen3.5 sizes, and Gemma 4 E2B/E4B; sampler defaults per profile
follow Unsloth's recommendations for each family. An initContainer
syncs GGUFs into a 100 GB local-path PVC via `uvx`-invoked `hf
download`, idempotent across restarts. First boot blocks on the
~60 GB sync; later starts are instant.

The README under `apps/llm` sets out the memory-bandwidth reasoning
for picking the MoE as the primary model on this i7-8700 and leaving
the dense 27B available for quality-first calls. Renovate will bump
the llama-swap and uv images on the usual cadence.