### PR TITLE
fix(llm): correct gguf filenames and init container image

### DIFF
--- a/apps/llm/configmap.yaml
+++ b/apps/llm/configmap.yaml
@@ -49,7 +49,7 @@ data:
       qwen3.6-35b-a3b:
         cmd: >-
           ${llama-server-base}
-          --model /models/Qwen3.6-35B-A3B-Q4_K_M.gguf
+          --model /models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
           --ctx-size 32768
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
@@ -101,7 +101,7 @@ data:
       gemma4-e4b:
         cmd: >-
           ${llama-server-base}
-          --model /models/gemma-4-e4b-it-Q5_K_M.gguf
+          --model /models/gemma-4-E4B-it-Q5_K_M.gguf
           --ctx-size 32768
           --temp 1.0 --top-p 0.95 --top-k 64
         ttl: 600
@@ -109,7 +109,7 @@ data:
       gemma4-e2b:
         cmd: >-
           ${llama-server-base}
-          --model /models/gemma-4-e2b-it-Q6_K.gguf
+          --model /models/gemma-4-E2B-it-Q6_K.gguf
           --ctx-size 32768
           --temp 1.0 --top-p 0.95 --top-k 64
         ttl: 600

--- a/apps/llm/deployment.yaml
+++ b/apps/llm/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       # take tens of minutes on a gigabit link with hf_transfer on.
       initContainers:
         - name: model-sync
-          image: ghcr.io/astral-sh/uv:python3.12-alpine
+          image: ghcr.io/astral-sh/uv:python3.12
           command: ["sh", "/scripts/sync.sh"]
           env:
             # uv's cache needs a writable HOME; the default /root is

--- a/apps/llm/model-sync.yaml
+++ b/apps/llm/model-sync.yaml
@@ -33,13 +33,13 @@ data:
         hf download "$repo" "$file" --local-dir /models
     }
 
-    download unsloth/Qwen3.6-35B-A3B-GGUF Qwen3.6-35B-A3B-Q4_K_M.gguf
+    download unsloth/Qwen3.6-35B-A3B-GGUF Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
     download unsloth/Qwen3.6-27B-GGUF     Qwen3.6-27B-Q5_K_M.gguf
     download unsloth/Qwen3.5-9B-GGUF      Qwen3.5-9B-Q5_K_M.gguf
     download unsloth/Qwen3.5-4B-GGUF      Qwen3.5-4B-Q5_K_M.gguf
     download unsloth/Qwen3.5-0.8B-GGUF    Qwen3.5-0.8B-Q6_K.gguf
-    download unsloth/gemma-4-e4b-it-GGUF  gemma-4-e4b-it-Q5_K_M.gguf
-    download unsloth/gemma-4-e2b-it-GGUF  gemma-4-e2b-it-Q6_K.gguf
+    download unsloth/gemma-4-e4b-it-GGUF  gemma-4-E4B-it-Q5_K_M.gguf
+    download unsloth/gemma-4-e2b-it-GGUF  gemma-4-E2B-it-Q6_K.gguf
 
     echo "All models present:"
     ls -lh /models


### PR DESCRIPTION
Unsloth's `Qwen3.6-35B-A3B-GGUF` repo only publishes UD (Unsloth-Dynamic) variants, so the filename becomes `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`. Gemma 4's GGUF filenames use uppercase `E2B`/`E4B` even though the HF URL slug is lowercase. Both were failing the first-boot download on main with 404s.

The init container's base image moves from `uv:python3.12-alpine` to `uv:python3.12` to sidestep a BusyBox `realpath: --:` error that surfaces during `hf download`.