### PR TITLE
fix(llm): flash-attn requires explicit on and correct uv tag

### DIFF
--- a/apps/llm/configmap.yaml
+++ b/apps/llm/configmap.yaml
@@ -36,11 +36,11 @@ data:
         /app/llama-server
         --host 127.0.0.1 --port ${PORT}
         --threads 6 --threads-batch 12
-        --flash-attn
+        --flash-attn on
         --mlock --no-mmap
         --cache-type-k q8_0 --cache-type-v q8_0
         --jinja
-        --chat-template-kwargs {"enable_thinking":false}
+        --chat-template-kwargs '{"enable_thinking":false}'
 
     models:
       # Primary: Qwen3.6 MoE. 35B total, 3B active per token, so CPU

--- a/apps/llm/deployment.yaml
+++ b/apps/llm/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       # take tens of minutes on a gigabit link with hf_transfer on.
       initContainers:
         - name: model-sync
-          image: ghcr.io/astral-sh/uv:python3.12
+          image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
           command: ["sh", "/scripts/sync.sh"]
           env:
             # uv's cache needs a writable HOME; the default /root is


### PR DESCRIPTION
Three fixes, all reproduced locally before push.

- `--flash-attn` in the current llama.cpp (`b8895`) now requires an `on`/`off`/`auto` argument; without one it consumed `--mlock` as its value and every profile exited with status 1. Pinned to `on`.
- `ghcr.io/astral-sh/uv:python3.12` does not exist, which is what caused the ErrImagePull on main. The Debian-slim tag is `python3.12-bookworm-slim`.
- `--chat-template-kwargs` JSON value needs outer single quotes in the YAML so llama-swap's argv split preserves `{"enable_thinking":false}` as a single token.

Smoke-tested end-to-end by running `ghcr.io/mostlygeek/llama-swap:cpu` locally with the actual configmap against `unsloth/Qwen3.5-0.8B-GGUF`: model loads, server responds, thinking stays off by default, per-request `{"enable_thinking": true}` override works.