### PR TITLE
feat: multimodal llm profiles and openwebui frontend

### DIFF
--- a/apps/kustomization.yaml
+++ b/apps/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - gatus
   - umami
   - llm
+  - openwebui

--- a/apps/llm/configmap.yaml
+++ b/apps/llm/configmap.yaml
@@ -18,6 +18,11 @@ data:
     # in the /v1/chat/completions body; the server honours request-
     # level chat_template_kwargs and overrides the CLI default.
     #
+    # Every profile also loads its vision projector (--mmproj), so a
+    # single endpoint serves both text chat and image input. The
+    # mmproj adds ~900 MB to the resident set when a profile is
+    # loaded; memory is unloaded alongside weights on TTL expiry.
+    #
     # Sampler defaults follow Unsloth's published per-family
     # settings for non-thinking mode; every sampler field is also
     # client-overridable (temperature=0 in a request wins over
@@ -28,9 +33,10 @@ data:
 
     # Shared llama-server flags. Threads match the i7-8700's physical
     # cores (6); threads-batch uses HT (12) since prompt eval is
-    # compute-bound and benefits. KV cache is Q8 per Unsloth guidance
-    # to cut memory without measurable quality loss, and mlock+no-mmap
-    # pins weights so the first token isn't stalled by page faults.
+    # compute-bound. KV cache is Q8 per Unsloth guidance, and
+    # mlock+no-mmap pins weights so the first token isn't stalled by
+    # page faults. --no-webui disables the llama-server built-in UI
+    # since OpenWebUI is the only frontend users should see.
     macros:
       llama-server-base: >-
         /app/llama-server
@@ -40,6 +46,7 @@ data:
         --mlock --no-mmap
         --cache-type-k q8_0 --cache-type-v q8_0
         --jinja
+        --no-webui
         --chat-template-kwargs '{"enable_thinking":false}'
 
     models:
@@ -50,28 +57,27 @@ data:
         cmd: >-
           ${llama-server-base}
           --model /models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+          --mmproj /models/mmproj-qwen3.6-35b-a3b.gguf
           --ctx-size 32768
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
         ttl: 600
 
-      # Dense Qwen3.6-27B. Better single-shot quality than the MoE on
-      # precise tasks but ~5x slower on this CPU; keep around for
-      # quality-first calls and be ready to wait.
       qwen3.6-27b:
         cmd: >-
           ${llama-server-base}
           --model /models/Qwen3.6-27B-Q5_K_M.gguf
+          --mmproj /models/mmproj-qwen3.6-27b.gguf
           --ctx-size 16384
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
         ttl: 600
 
-      # Dense Qwen3.5-9B. Fast enough for interactive use.
       qwen3.5-9b:
         cmd: >-
           ${llama-server-base}
           --model /models/Qwen3.5-9B-Q5_K_M.gguf
+          --mmproj /models/mmproj-qwen3.5-9b.gguf
           --ctx-size 32768
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
@@ -81,6 +87,7 @@ data:
         cmd: >-
           ${llama-server-base}
           --model /models/Qwen3.5-4B-Q5_K_M.gguf
+          --mmproj /models/mmproj-qwen3.5-4b.gguf
           --ctx-size 32768
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
@@ -90,18 +97,19 @@ data:
         cmd: >-
           ${llama-server-base}
           --model /models/Qwen3.5-0.8B-Q6_K.gguf
+          --mmproj /models/mmproj-qwen3.5-0.8b.gguf
           --ctx-size 32768
           --temp 0.7 --top-p 0.8 --top-k 20 --min-p 0.0
           --presence-penalty 1.5 --repeat-penalty 1.0
         ttl: 600
 
       # Gemma 4 general defaults from Google/Unsloth: temp 1.0,
-      # top_p 0.95, top_k 64. Repetition penalty stays disabled
-      # unless loops appear.
+      # top_p 0.95, top_k 64. Repetition penalty disabled by default.
       gemma4-e4b:
         cmd: >-
           ${llama-server-base}
           --model /models/gemma-4-E4B-it-Q5_K_M.gguf
+          --mmproj /models/mmproj-gemma4-e4b.gguf
           --ctx-size 32768
           --temp 1.0 --top-p 0.95 --top-k 64
         ttl: 600
@@ -110,6 +118,7 @@ data:
         cmd: >-
           ${llama-server-base}
           --model /models/gemma-4-E2B-it-Q6_K.gguf
+          --mmproj /models/mmproj-gemma4-e2b.gguf
           --ctx-size 32768
           --temp 1.0 --top-p 0.95 --top-k 64
         ttl: 600

--- a/apps/llm/model-sync.yaml
+++ b/apps/llm/model-sync.yaml
@@ -6,33 +6,40 @@ metadata:
 data:
   sync.sh: |
     #!/bin/sh
-    # Idempotent GGUF downloader: for each model below, check the
+    # Idempotent GGUF downloader. For each model below, check the
     # target file on the PVC; if missing, fetch from Hugging Face via
-    # uvx (no install step, ephemeral venv managed by uv). Runs as an
-    # initContainer on the llama-swap Deployment, so pod restarts are
-    # free but the first boot has to download ~60 GB.
+    # uvx (ephemeral venv managed by uv, no install step).
     #
-    # HF_TOKEN (sops-encrypted secret, mounted as env) unlocks PRO
-    # download speeds; hf download picks it up automatically.
-    # HF_HUB_ENABLE_HF_TRANSFER turns on the chunked parallel
-    # downloader, roughly doubling throughput on a gigabit link.
+    # mmproj files share the filename `mmproj-F16.gguf` across repos,
+    # so we rename each to a model-specific name during download to
+    # keep the flat /models layout unambiguous.
+    #
+    # HF_TOKEN (sops-encrypted secret) unlocks Pro download speeds;
+    # hf picks it up automatically from env. HF_HUB_ENABLE_HF_TRANSFER
+    # turns on the chunked parallel downloader.
     set -eu
     cd /models
-
     export HF_HUB_ENABLE_HF_TRANSFER=1
 
+    # download <repo> <source-filename> [<dest-filename>]
+    # The third argument lets us rename (needed for mmproj dedupe).
     download() {
       repo="$1"
-      file="$2"
-      if [ -f "$file" ]; then
-        echo "$file already present"
+      src="$2"
+      dst="${3:-$2}"
+      if [ -f "$dst" ]; then
+        echo "$dst already present"
         return
       fi
-      echo "Downloading $file from $repo"
+      echo "Downloading $repo::$src -> $dst"
       uvx --with hf_transfer --from huggingface_hub \
-        hf download "$repo" "$file" --local-dir /models
+        hf download "$repo" "$src" --local-dir /models
+      if [ "$src" != "$dst" ]; then
+        mv "/models/$src" "/models/$dst"
+      fi
     }
 
+    # Text weights
     download unsloth/Qwen3.6-35B-A3B-GGUF Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
     download unsloth/Qwen3.6-27B-GGUF     Qwen3.6-27B-Q5_K_M.gguf
     download unsloth/Qwen3.5-9B-GGUF      Qwen3.5-9B-Q5_K_M.gguf
@@ -40,6 +47,15 @@ data:
     download unsloth/Qwen3.5-0.8B-GGUF    Qwen3.5-0.8B-Q6_K.gguf
     download unsloth/gemma-4-e4b-it-GGUF  gemma-4-E4B-it-Q5_K_M.gguf
     download unsloth/gemma-4-e2b-it-GGUF  gemma-4-E2B-it-Q6_K.gguf
+
+    # Vision projectors, one per model, renamed to avoid collision
+    download unsloth/Qwen3.6-35B-A3B-GGUF mmproj-F16.gguf mmproj-qwen3.6-35b-a3b.gguf
+    download unsloth/Qwen3.6-27B-GGUF     mmproj-F16.gguf mmproj-qwen3.6-27b.gguf
+    download unsloth/Qwen3.5-9B-GGUF      mmproj-F16.gguf mmproj-qwen3.5-9b.gguf
+    download unsloth/Qwen3.5-4B-GGUF      mmproj-F16.gguf mmproj-qwen3.5-4b.gguf
+    download unsloth/Qwen3.5-0.8B-GGUF    mmproj-F16.gguf mmproj-qwen3.5-0.8b.gguf
+    download unsloth/gemma-4-e4b-it-GGUF  mmproj-F16.gguf mmproj-gemma4-e4b.gguf
+    download unsloth/gemma-4-e2b-it-GGUF  mmproj-F16.gguf mmproj-gemma4-e2b.gguf
 
     echo "All models present:"
     ls -lh /models

--- a/apps/openwebui/deployment.yaml
+++ b/apps/openwebui/deployment.yaml
@@ -1,0 +1,110 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openwebui
+  namespace: openwebui
+  labels:
+    app.kubernetes.io/name: openwebui
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openwebui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openwebui
+    spec:
+      containers:
+        - name: openwebui
+          image: ghcr.io/open-webui/open-webui:main
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            # Point at llama-swap's internal ClusterIP Service. OpenAI
+            # key is required but unused because llama-swap doesn't
+            # authenticate; a dummy satisfies the client.
+            - name: OPENAI_API_BASE_URL
+              value: http://llama-swap.llm.svc.cluster.local/v1
+            - name: OPENAI_API_KEY
+              value: sk-llama-swap-unused
+            - name: ENABLE_OPENAI_API
+              value: "true"
+            - name: ENABLE_OLLAMA_API
+              value: "false"
+
+            # Open WebUI forces the first registered user to admin
+            # regardless of DEFAULT_USER_ROLE (see routers/auths.py:
+            # get_num_users == 1 -> role admin). Subsequent signups
+            # land as regular users; tailnet membership is already
+            # the trust boundary, so no extra approval step.
+            - name: WEBUI_AUTH
+              value: "true"
+            - name: ENABLE_SIGNUP
+              value: "true"
+            - name: DEFAULT_USER_ROLE
+              value: user
+
+            # Branding. WEBUI_NAME is a plain local string; upstream
+            # appends " (Open WebUI)" to any non-default name.
+            # CUSTOM_NAME deliberately avoided because it phones home
+            # to api.openwebui.com to fetch a themed config.
+            - name: WEBUI_NAME
+              value: Farooqui.ai Chat
+
+            # Task model handles background jobs: chat-title generation,
+            # auto-tagging, autocomplete. Routing to the tiny Gemma 4
+            # E2B profile keeps these near-instant and avoids waking
+            # the big weights.
+            - name: TASK_MODEL_EXTERNAL
+              value: gemma4-e2b
+
+            # Telemetry / phone-home off. All three are needed because
+            # they gate separate upstream libraries (chromadb, scarf,
+            # generic DNT).
+            - name: ANONYMIZED_TELEMETRY
+              value: "false"
+            - name: SCARF_NO_ANALYTICS
+              value: "true"
+            - name: DO_NOT_TRACK
+              value: "true"
+
+            # Community sharing publishes chat prompts to Open WebUI's
+            # public community index. Off.
+            - name: ENABLE_COMMUNITY_SHARING
+              value: "false"
+
+            # Persist DB/secret-key across restarts.
+            - name: DATA_DIR
+              value: /app/backend/data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              memory: 2Gi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+          volumeMounts:
+            - name: data
+              mountPath: /app/backend/data
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: data

--- a/apps/openwebui/ingress.yaml
+++ b/apps/openwebui/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openwebui
+  namespace: openwebui
+spec:
+  ingressClassName: traefik
+  # No secretName: Traefik's default TLSStore serves the
+  # *.farooqui.ai wildcard. Tailnet-only via the Cloudflare wildcard
+  # record; no CF origin-pull TLSOption because traffic does not
+  # transit Cloudflare.
+  tls:
+    - hosts:
+        - chat.farooqui.ai
+  rules:
+    - host: chat.farooqui.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: openwebui
+                port:
+                  number: 80

--- a/apps/openwebui/kustomization.yaml
+++ b/apps/openwebui/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openwebui
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/openwebui/namespace.yaml
+++ b/apps/openwebui/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openwebui

--- a/apps/openwebui/pvc.yaml
+++ b/apps/openwebui/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+  namespace: openwebui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      # User accounts, chat history, uploaded image attachments. SQLite
+      # lives here too; 10 Gi is generous for personal use.
+      storage: 10Gi

--- a/apps/openwebui/service.yaml
+++ b/apps/openwebui/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openwebui
+  namespace: openwebui
+spec:
+  selector:
+    app.kubernetes.io/name: openwebui
+  ports:
+    - name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
Two commits:

- `feat(llm)` — every profile gains a `--mmproj` pointing at the model-specific vision projector, so a single endpoint serves both text chat and image input. model-sync downloads seven additional `mmproj-F16.gguf` files (~900 MB each) and renames them to keep the flat `/models` layout unambiguous. `--no-webui` on the shared llama-server flags removes the built-in UI.
- `feat(openwebui)` — new `apps/openwebui` module hosts [Open WebUI](https://github.com/open-webui/open-webui) on `chat.farooqui.ai` (tailnet-only via the wildcard). Points at `llama-swap.llm.svc.cluster.local` as its OpenAI-compatible backend. Telemetry knobs set per source audit of the cloned upstream repo: `ANONYMIZED_TELEMETRY=false`, `SCARF_NO_ANALYTICS=true`, `DO_NOT_TRACK=true` guard transitive deps; `ENABLE_COMMUNITY_SHARING=false` keeps prompts off Open WebUI's public index.

First boot downloads ~5 GB of mmproj files on top of the existing GGUFs.