### PR TITLE
feat(infra): stakater/reloader for configmap and secret rollouts

### DIFF
--- a/apps/gatus/deployment.yaml
+++ b/apps/gatus/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: gatus
   labels:
     app.kubernetes.io/name: gatus
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/apps/llm/deployment.yaml
+++ b/apps/llm/deployment.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: llm
   labels:
     app.kubernetes.io/name: llama-swap
+  annotations:
+    # Reloader watches every ConfigMap and Secret this Deployment
+    # mounts or references via env; a content change triggers a
+    # rollout automatically. Covers both the llama-swap config and
+    # the model-sync script without per-resource wiring.
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   strategy:

--- a/apps/openwebui/deployment.yaml
+++ b/apps/openwebui/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openwebui
   labels:
     app.kubernetes.io/name: openwebui
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   strategy:

--- a/apps/umami/deployment.yaml
+++ b/apps/umami/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: umami
   labels:
     app.kubernetes.io/name: umami
+  annotations:
+    reloader.stakater.com/auto: "true"
 spec:
   replicas: 1
   selector:

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - tailscale-operator
   - observability
   - reflector
+  - reloader
   - postgres

--- a/infrastructure/controllers/reloader/kustomization.yaml
+++ b/infrastructure/controllers/reloader/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/reloader/namespace.yaml
+++ b/infrastructure/controllers/reloader/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: reloader

--- a/infrastructure/controllers/reloader/release.yaml
+++ b/infrastructure/controllers/reloader/release.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reloader
+  namespace: reloader
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: reloader
+      version: "2.2.11"
+      sourceRef:
+        kind: HelmRepository
+        name: stakater
+        namespace: reloader
+      interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Watches ConfigMaps and Secrets cluster-wide; when the content of
+    # one referenced by a Deployment/StatefulSet/DaemonSet changes,
+    # rolls the workload. Two opt-in modes:
+    #   * `reloader.stakater.com/auto: "true"` on a workload — watch
+    #     every ConfigMap/Secret that workload mounts or references
+    #     via env.
+    #   * `reloader.stakater.com/search: "true"` on a specific
+    #     ConfigMap/Secret — watch workloads that have an explicit
+    #     match annotation; finer-grained but more wiring per app.
+    reloader:
+      # Auto mode is the ergonomic default for a homelab where every
+      # app's config is in git anyway; there's no risk of unexpected
+      # restarts from third-party changes.
+      watchGlobally: true
+      reloadStrategy: annotations
+      # Conservative resources; reloader is idle most of the time and
+      # just watches the k8s API.
+      deployment:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            memory: 128Mi

--- a/infrastructure/controllers/reloader/repository.yaml
+++ b/infrastructure/controllers/reloader/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: stakater
+  namespace: reloader
+spec:
+  interval: 24h
+  url: https://stakater.github.io/stakater-charts


### PR DESCRIPTION
Adds [stakater/reloader](https://github.com/stakater/Reloader) chart v2.2.11 (app v1.4.16) as a new controller under `infrastructure/controllers/reloader`. Watches ConfigMaps and Secrets cluster-wide and rolls any workload annotated `reloader.stakater.com/auto: "true"` when a referenced resource changes.

`llm`, `gatus`, `umami` and `openwebui` Deployments pick up the annotation in this PR; the pattern is one line to opt any other workload in later. Closes the foot-gun where in-place ConfigMap edits left pods running on stale content until a manual `kubectl rollout restart`.