### PR TITLE
fix(backups): rotate r2 access keys for restic

### DIFF
--- a/nixos/hosts/homelab/secrets.yaml
+++ b/nixos/hosts/homelab/secrets.yaml
@@ -1,7 +1,7 @@
 tailscale_auth_key: ENC[AES256_GCM,data:0cui7QM/iXBJSt/ivOtOU7zXGb5+Uhdo7s29M4v50kdoo7SSrtsINwst98Q0Srx/My0PQg6iAQpUBJc26g==,iv:GPlt/QbXmJWpJ3/0ILGVuRCeWGfVrZMJdeggExdwp4E=,tag:FwBJojX6syTQgVPw4uzkeQ==,type:str]
 r2_repository_url: ENC[AES256_GCM,data:xWkResAAs8Eqai5k7PiUuqz3YexV2SRM96WI+PaJKB79PzNyiu1I6rnodqhtPdAmRorpET6I6sx6zY40wrbei5ZpK2cQhs63y/OHCA==,iv:WFbW3VuSSUznujXM8XqTiSIwxV2qQWbn9Dib4evsm1A=,tag:C7ZPGV7pCDPRse/g1oN2mQ==,type:str]
-r2_access_key_id: ENC[AES256_GCM,data:BjuDjEk3FJcT0x6ALXoKC7r+LEPiUAR7ozrund8Abrs=,iv:BjMxIJbWwjtsEUJLrYYTEUxfPkVypcSxAv9VqKkfH34=,tag:5ldzcIHn54WGyJw49bXPlw==,type:str]
-r2_secret_access_key: ENC[AES256_GCM,data:i7PRY4HTvncyVl/sRxGL/FLYFgHzuG5BGjub+USmRO9Q4Aqg6Y5gCkOw/opf3XpJyK7QkjpV2CL/T0P11xKzPg==,iv:J1OAtQWBS4c0Nu9KDEodYYD7lMRW9TOWDC2GUdxbFQU=,tag:K0FCFvkZEYU68oLIHa3dVg==,type:str]
+r2_access_key_id: ENC[AES256_GCM,data:RjnfpF6qH5WrwsSvLId9UbugcrfWifg45PLZlTLS/to=,iv:vqxHrf1SO/v7bsEBCn7ZDaWGMUZMCtMmQYiPlhHUb7Q=,tag:eRqopNNcC+zq0b00/NMmbg==,type:str]
+r2_secret_access_key: ENC[AES256_GCM,data:l+AfWcUUy2GNHxdcIL6d7N534H7FOg1OHPFmtcCwoaKmdr/MocMkKztdcJdINDEuZ2Vi9FPA6HASILUBUHIdzw==,iv:tvGK8HbflKStdC0/aHxCfNCLcdfiz1s1iHqdmUrXgCY=,tag:lDnnHcjPDFcHUAgBlHqLfQ==,type:str]
 restic_repo_password: ENC[AES256_GCM,data:B93LlUGm19ayR2CFrXEB74oS2nXwigdVXBr+XvnViX52iJCkkXLAJPilbqJ/qxuRhzynazBirs4bIwrdcX1X9A==,iv:877nuiFJ63x8Yr8acVg8vosQkyVOCsPBC57PDYPknWo=,tag:IJwTdoFks7aO23Jy71H2iA==,type:str]
 sops:
     age:
@@ -23,7 +23,7 @@ sops:
             U3lFR2FEc2x3aW5jdnMvRzBFYXQwdEEKw2lrCWqh3M+THaD6ULhga5kwO7JBbNXm
             3wH5CRpuvg80XrrB5vAS0Mwpg/vCzy7XTyCX4TBKvRZbHp+jUr/2Ig==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-21T20:00:45Z"
-    mac: ENC[AES256_GCM,data:q+AMwmmjQcHg/pfKaNbsIoOpb7eXBXoH3zbWXHFGLp7YveHZm20GVpkBRubhh8Tm62JLJOLpEmH7FhwSAZWGREuJdaiA0nrrfoufMIKKeFDHaKvXbe7jlPqDob9IuN5SHSBQdJ+E2qu3IbmvQPWRhTI46xxsrVTLS2qTB8d2onA=,iv:bJO/D3k8I7dftsj29AWXP/xACqftcoNVR9tzfh+2H4M=,tag:Idhc3vxF1y31dyDABo/LJQ==,type:str]
+    lastmodified: "2026-04-30T23:38:10Z"
+    mac: ENC[AES256_GCM,data:aSvhX7hXY2QHQmNwnAAeDKThWkJ9nYMJ5hTBPVmMuguT9kHVybIVBqziPcd4l3DUqwdxEWL4gXgLTlRvYeCXgydgtoRpucLCQ3qOHYG6xz/DW97RGvrKoOYgvGdYzQ2SIzznFgOjj/t2k1UZ6Z+JGFoGSpz28XtiKJhmf8qRCcU=,iv:+hZNMiJ2TRD7+5hu3unJ94rwztUy55EEYSAWwzFwRcQ=,tag:0lM4mu665CwD82omIvRUEA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
## Summary

The R2 access keys deployed to the homelab returned `Stat: Unauthorized` on every nightly restic run since the timer first fired on 21 April, so the `homelab` bucket has stayed empty. Rotated to a fresh R2 API token scoped Object Read & Write on the `homelab` bucket; sops re-encrypted to both age recipients (laptop + host SSH key).

## Test plan

- [ ] `gh pr checks` — pre-commit passes
- [ ] After merge, trigger `nixos-upgrade.service` on homelab so the new secrets get decrypted into `/run/secrets/`
- [ ] Restart `restic-backups-homelab.service` and confirm `created restic repository … at s3:https://….r2.cloudflarestorage.com/homelab` plus a snapshot in `restic snapshots`
- [ ] Cloudflare dashboard shows non-zero object count on the `homelab` bucket and a recent "last used" timestamp on the new token