### PR TITLE
fix(backups): exclude regenerable PVs from restic

### DIFF
--- a/nixos/hosts/homelab/default.nix
+++ b/nixos/hosts/homelab/default.nix
@@ -311,6 +311,19 @@
       "/var/lib/rancher/k3s/server/db"
       "/var/lib/rancher/k3s/storage"
     ];
+    # Exclude PVs whose contents are regenerable on a fresh cluster:
+    # LLM weights re-pull from HuggingFace, Prometheus and Loki history
+    # are ephemeral by nature, Grafana dashboards live in GitOps, and
+    # OpenWebUI's PV holds chat/RAG state we're treating as transient.
+    # Patterns match the local-path provisioner's
+    # pvc-<uuid>_<namespace>_<pvc-name> directory naming.
+    exclude = [
+      "pvc-*_llm_models"
+      "pvc-*_openwebui_data"
+      "pvc-*_observability_prometheus-*"
+      "pvc-*_observability_storage-loki-*"
+      "pvc-*_observability_grafana"
+    ];
     timerConfig = {
       OnCalendar = "daily";
       Persistent = true;


### PR DESCRIPTION
## Summary

The first successful restic run picked up everything under `/var/lib/rancher/k3s/storage`, which is dominated by 63 G of LLM model weights plus Prometheus and OpenWebUI state. None of that needs surviving a cluster rebuild — model weights re-pull from HuggingFace, Prometheus/Loki history is ephemeral, Grafana dashboards are GitOps-managed, and OpenWebUI chat/RAG state is treated as transient.

After this change a snapshot is roughly 125 MB (umami postgres, gatus, and k3s embedded etcd).

The 31 G of orphan packs from the cancelled first run have already been removed from the `homelab` bucket; the next restic timer fires against an empty repo.

## Test plan

- [ ] `gh pr checks` — pre-commit passes
- [ ] After merge, rebuild homelab and trigger `restic-backups-homelab.service`
- [ ] `restic snapshots` shows one snapshot, repo size around 125 MB
- [ ] CF dashboard reflects the smaller bucket footprint