### PR TITLE
fix(homelab): drop deprecated --update-input from auto-upgrade

### DIFF
--- a/nixos/hosts/homelab/default.nix
+++ b/nixos/hosts/homelab/default.nix
@@ -351,11 +351,15 @@
   # leave the previous generation running; no operator action is needed
   # unless a build error appears in the logs. persistent = true means a
   # missed timer (host was off) runs on next boot.
+  #
+  # --override-input replaces the locked nixpkgs entry for this rebuild
+  # only, without trying to write flake.lock back into the GitHub-fetched
+  # flake (which lives in a read-only nix store path and would error).
   system.autoUpgrade = {
     enable = true;
     flake = "github:shariq-farooqui/infra?dir=nixos";
     flags = [
-      "--update-input" "nixpkgs"
+      "--override-input" "nixpkgs" "github:nixos/nixpkgs/nixos-25.11"
       "-L" # stream build logs to journald
     ];
     dates = "weekly";


### PR DESCRIPTION
## Summary

`nixos-upgrade.service` has been failing on every weekly run since 27 April with:

```
error: cannot write modified lock file of flake 'github:shariq-farooqui/infra?dir=nixos'
```

The cause is `--update-input nixpkgs` in `system.autoUpgrade.flags` — Nix wants to persist the freshly resolved `nixpkgs` ref into `flake.lock`, but the flake is fetched from GitHub into a read-only nix store path so the write fails. The flag is also deprecated in favour of `nix flake update`.

`--override-input` expresses the same intent (use the latest tip of `nixos-25.11` on each rebuild) without writing anything back.

## Verified

- Smoke-tested `nix build --refresh --override-input nixpkgs github:nixos/nixpkgs/nixos-25.11 --no-link 'github:shariq-farooqui/infra?dir=nixos#nixosConfigurations.homelab.config.system.build.toplevel'` on the homelab — builds cleanly against `nixos-system-homelab-25.11.20260429.755f5aa` (newer than the currently locked rev), with no lock-write errors.

## Test plan

- [ ] `gh pr checks` — pre-commit passes
- [ ] After merge, rebuild homelab and `sudo systemctl start nixos-upgrade.service` finishes with `code=exited, status=0/SUCCESS`