### PR TITLE
fix(homelab): pin net.ipv4.ip_forward=1 for k3s LB ingress

### DIFF
--- a/nixos/hosts/homelab/default.nix
+++ b/nixos/hosts/homelab/default.nix
@@ -132,6 +132,15 @@
     ];
   };
 
+  # IPv4 forwarding for k3s pod networking and klipper-lb DNAT. Without
+  # this, traffic arriving on the public NIC for the LoadBalancer IP
+  # never crosses into the cluster network namespace and the public
+  # ingress paths black-hole. NixOS leaves this off by default; k3s
+  # itself sets it at runtime via sysctl, but a configuration switch
+  # resets it back to the kernel default before k3s gets another chance,
+  # so it has to be declared here to survive activation.
+  boot.kernel.sysctl."net.ipv4.ip_forward" = 1;
+
   # Operator shell ergonomics.
   #
   # zsh with syntax highlighting, ghost-text history suggestions, and a


### PR DESCRIPTION
## Summary

The auto-upgrade activation at 01:12Z (nixpkgs 755f5aa) flipped `net.ipv4.ip_forward` back to the kernel default of `0`. Public ingress went dark from that minute: SYNs were still landing in the host's nat table (klipper-lb DNAT counter incremented during a probe), but with forwarding off they never crossed into the cluster netns, so Traefik stopped seeing requests. ICMP to the public IP still worked, which is why `ping` looked fine while everything TCP-shaped on 80/443 timed out.

k3s sets `ip_forward` itself at startup, but a `nixos-rebuild switch` wipes runtime sysctls before k3s gets another opportunity to reapply, so the value has to be declared in the flake.

## Verified

- Reproduced the symptom: `sysctl net.ipv4.ip_forward` returned `0` on the live host while sites timed out.
- DNAT counter `ip daddr 167.235.112.161 ... dport 443 -> KUBE-EXT-LODJXQNF3DWSNB7B` incremented in step with external SYN attempts, proving the SYNs reached the host but were never forwarded.
- Last successful Traefik request: `2026-05-01T00:11:43Z`. Generation 5 activation: `01:12:08 BST`. One minute gap; matches.

## Test plan

- [ ] `gh pr checks` — pre-commit passes
- [ ] After merge, rebuild homelab and confirm `sysctl net.ipv4.ip_forward` is `1`
- [ ] `curl -I https://farooqui.ai` returns 200 from outside the tailnet